### PR TITLE
Add admin panel for entering predictions

### DIFF
--- a/app/(dashboard)/admin/AdminInputForm.tsx
+++ b/app/(dashboard)/admin/AdminInputForm.tsx
@@ -1,0 +1,321 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle
+} from '@/components/ui/card';
+import { Select } from '@/components/ui/select';
+import { Button } from '@/components/ui/button';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow
+} from '@/components/ui/table';
+import { cn } from '@/lib/utils';
+import { AdminPrediction, FixturesData, Participant } from '@/lib/definitions';
+
+type TeamsArr = { id: number; name: string; short_name: string }[];
+
+type Props = {
+  participants: Participant[];
+  existingPredictions: AdminPrediction[];
+  teamsArr: TeamsArr;
+  predictionWeekFixtures: FixturesData[];
+  currentGwNumber: number;
+  currentGameId: number;
+};
+
+type ParticipantRowProps = {
+  participant: Participant;
+  userPredictions: AdminPrediction[];
+  teamsArr: TeamsArr;
+  predictionWeekFixtures: FixturesData[];
+  currentGwNumber: number;
+};
+
+function FixtureBadge({
+  teamSelected,
+  teamOpposing,
+  location,
+  className
+}: {
+  teamSelected: string;
+  teamOpposing: string;
+  location: string;
+  className?: string;
+}) {
+  const homeTeam = location === 'Home' ? teamSelected : teamOpposing;
+  const awayTeam = location === 'Away' ? teamSelected : teamOpposing;
+  const homeIsPick = location === 'Home';
+
+  return (
+    <span
+      className={cn('text-xs rounded px-2 py-1 whitespace-nowrap', className)}
+    >
+      {homeIsPick ? <strong>{homeTeam}</strong> : homeTeam}
+      {' v '}
+      {!homeIsPick ? <strong>{awayTeam}</strong> : awayTeam}
+    </span>
+  );
+}
+
+function ParticipantRow({
+  participant,
+  userPredictions,
+  teamsArr,
+  predictionWeekFixtures,
+  currentGwNumber
+}: ParticipantRowProps) {
+  const predictionGw = currentGwNumber + 1;
+  const existingThisWeek = userPredictions.find(
+    (p) => p.fpl_gw === predictionGw
+  );
+  const previousPredictions = userPredictions.filter(
+    (p) => p.fpl_gw !== predictionGw
+  );
+
+  const [selectedTeam, setSelectedTeam] = useState('Select');
+  const [selectedOutcome, setSelectedOutcome] = useState('Select');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [submitted, setSubmitted] = useState<AdminPrediction | null>(null);
+
+  const displayedThisWeek = submitted ?? existingThisWeek ?? null;
+
+  const previousTeams = userPredictions.map((p) => p.team_selected);
+  const roundNumber = userPredictions.length + 1;
+  const allTeamNames = teamsArr.map((t) => t.name);
+
+  const teamSelectId = `team-${participant.id}`;
+  const outcomeSelectId = `outcome-${participant.id}`;
+
+  const selectedTeamObj = teamsArr.find((t) => t.name === selectedTeam);
+  const selectedTeamFixture = predictionWeekFixtures.find(
+    (f) => f.team_a === selectedTeamObj?.id || f.team_h === selectedTeamObj?.id
+  );
+  const isAway = selectedTeamFixture?.team_a === selectedTeamObj?.id;
+  const opposingTeamId = isAway
+    ? selectedTeamFixture?.team_h
+    : selectedTeamFixture?.team_a;
+  const opposingTeamName = teamsArr.find((t) => t.id === opposingTeamId)?.name;
+  const selectedTeamLocation = isAway ? 'Away' : 'Home';
+
+  const handleSubmit = async () => {
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/admin/predictions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          target_user_id: participant.id,
+          team_selected: selectedTeam,
+          team_opposing: opposingTeamName,
+          team_selected_location: selectedTeamLocation,
+          result_selected: selectedOutcome,
+          fpl_gw: selectedTeamFixture?.event,
+          round_number: roundNumber
+        })
+      });
+      if (!res.ok) throw new Error('Failed to submit');
+      setSubmitted({
+        user_id: participant.id,
+        team_selected: selectedTeam,
+        team_opposing: opposingTeamName ?? '',
+        team_selected_location: selectedTeamLocation,
+        result_selected: selectedOutcome,
+        correct: null,
+        fpl_gw: selectedTeamFixture?.event ?? null,
+        round_number: roundNumber,
+        prediction_submitted_time: new Date().toISOString()
+      });
+    } catch {
+      setError('Submission failed. Please try again.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <TableRow>
+      <TableCell className="align-top font-medium whitespace-nowrap">
+        <div>{participant.name ?? '—'}</div>
+        <div className="text-xs text-muted-foreground">{participant.email}</div>
+      </TableCell>
+
+      <TableCell className="align-top">
+        {previousPredictions.length === 0 ? (
+          <span className="text-xs text-muted-foreground">
+            No previous picks
+          </span>
+        ) : (
+          <div className="flex flex-col gap-1">
+            {previousPredictions.map((p) => {
+              const bg =
+                p.correct === true
+                  ? 'bg-green-200'
+                  : p.correct === false
+                    ? 'bg-red-200'
+                    : 'bg-gray-100';
+              return (
+                <span
+                  key={p.round_number}
+                  className={`text-xs rounded px-2 py-1 whitespace-nowrap ${bg}`}
+                >
+                  GW{p.fpl_gw}: {p.team_selected}
+                </span>
+              );
+            })}
+          </div>
+        )}
+      </TableCell>
+
+      <TableCell className="align-top">
+        {displayedThisWeek ? (
+          <FixtureBadge
+            teamSelected={displayedThisWeek.team_selected}
+            teamOpposing={displayedThisWeek.team_opposing}
+            location={displayedThisWeek.team_selected_location}
+            className="bg-gray-100"
+          />
+        ) : predictionWeekFixtures.length === 0 ? (
+          <span className="text-xs text-muted-foreground">
+            No fixtures for GW{predictionGw}
+          </span>
+        ) : (
+          <div className="flex flex-col gap-2">
+            <div className="flex gap-2 items-end flex-wrap">
+              <div className="flex flex-col gap-1">
+                <label htmlFor={teamSelectId} className="text-xs font-medium">
+                  Team
+                </label>
+                <Select
+                  id={teamSelectId}
+                  options={['Select', ...allTeamNames]}
+                  disabledOptions={['Select', ...previousTeams]}
+                  value={selectedTeam}
+                  onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
+                    setSelectedTeam(e.target.value);
+                    setSelectedOutcome('Select');
+                    setError(null);
+                  }}
+                  disabled={isSubmitting}
+                />
+              </div>
+
+              <div className="flex flex-col gap-1">
+                <label
+                  htmlFor={outcomeSelectId}
+                  className="text-xs font-medium"
+                >
+                  Outcome
+                </label>
+                <Select
+                  id={outcomeSelectId}
+                  options={['Select', 'Win', 'Draw']}
+                  disabledOptions={['Select']}
+                  value={selectedOutcome}
+                  onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
+                    setSelectedOutcome(e.target.value);
+                    setError(null);
+                  }}
+                  disabled={selectedTeam === 'Select' || isSubmitting}
+                />
+              </div>
+
+              <Button
+                size="sm"
+                onClick={handleSubmit}
+                disabled={
+                  selectedTeam === 'Select' ||
+                  selectedOutcome === 'Select' ||
+                  !opposingTeamName ||
+                  isSubmitting
+                }
+              >
+                {isSubmitting ? 'Saving...' : 'Save'}
+              </Button>
+            </div>
+
+            {selectedTeam !== 'Select' && (
+              <p className="text-xs text-muted-foreground">
+                {opposingTeamName ? (
+                  selectedTeamLocation === 'Home' ? (
+                    <>
+                      <strong>{selectedTeam}</strong> v {opposingTeamName}
+                    </>
+                  ) : (
+                    <>
+                      {opposingTeamName} v <strong>{selectedTeam}</strong>
+                    </>
+                  )
+                ) : (
+                  `No fixture found for ${selectedTeam} in GW${predictionGw}`
+                )}
+              </p>
+            )}
+
+            {error && <p className="text-xs text-red-500">{error}</p>}
+          </div>
+        )}
+      </TableCell>
+    </TableRow>
+  );
+}
+
+export default function AdminInputForm({
+  participants,
+  existingPredictions,
+  teamsArr,
+  predictionWeekFixtures,
+  currentGwNumber,
+  currentGameId
+}: Props) {
+  return (
+    <Card className="rounded-xl bg-white shadow-sm">
+      <CardHeader className="p-4 md:p-6">
+        <CardTitle>Admin: Enter Predictions</CardTitle>
+        <CardDescription>
+          GW{currentGwNumber + 1} predictions — Game #{currentGameId}. Submitted
+          predictions are read-only.
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent className="p-2 md:p-6 md:pt-0 overflow-x-auto">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Participant</TableHead>
+              <TableHead>Previous picks (this game)</TableHead>
+              <TableHead>GW{currentGwNumber + 1} pick</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {participants.map((participant) => {
+              const userPredictions = existingPredictions.filter(
+                (p) => p.user_id === participant.id
+              );
+              return (
+                <ParticipantRow
+                  key={participant.id}
+                  participant={participant}
+                  userPredictions={userPredictions}
+                  teamsArr={teamsArr}
+                  predictionWeekFixtures={predictionWeekFixtures}
+                  currentGwNumber={currentGwNumber}
+                />
+              );
+            })}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/(dashboard)/admin/loading.tsx
+++ b/app/(dashboard)/admin/loading.tsx
@@ -1,0 +1,33 @@
+export default function AdminLoading() {
+  return (
+    <div className="rounded-xl bg-white shadow-sm p-4 md:p-6 animate-pulse">
+      {/* Header */}
+      <div className="mb-6">
+        <div className="h-6 w-48 rounded-full bg-gray-200 mb-2" />
+        <div className="h-4 w-72 rounded-full bg-gray-200" />
+      </div>
+
+      {/* Table header */}
+      <div className="flex gap-4 mb-3 pb-3 border-b border-gray-100">
+        <div className="h-4 w-28 rounded-full bg-gray-200" />
+        <div className="h-4 w-40 rounded-full bg-gray-200" />
+        <div className="h-4 w-32 rounded-full bg-gray-200" />
+      </div>
+
+      {/* Table rows */}
+      {Array.from({ length: 6 }).map((_, i) => (
+        <div key={i} className="flex gap-4 py-4 border-b border-gray-50">
+          <div className="flex flex-col gap-1 w-28">
+            <div className="h-4 w-24 rounded-full bg-gray-200" />
+            <div className="h-3 w-28 rounded-full bg-gray-100" />
+          </div>
+          <div className="flex gap-1 w-40">
+            <div className="h-6 w-20 rounded bg-gray-100" />
+            <div className="h-6 w-20 rounded bg-gray-100" />
+          </div>
+          <div className="h-6 w-32 rounded bg-gray-100" />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/app/(dashboard)/admin/page.tsx
+++ b/app/(dashboard)/admin/page.tsx
@@ -1,0 +1,135 @@
+import { redirect } from 'next/navigation';
+import { auth } from '@/lib/auth';
+import { sql } from '@vercel/postgres';
+import { MIN_GW } from '@/lib/constants';
+import { AdminPrediction, Participant } from '@/lib/definitions';
+import AdminInputForm from './AdminInputForm';
+
+export default async function AdminPage() {
+  const session = await auth();
+
+  if (session?.user?.email !== process.env.NEXT_PUBLIC_MY_EMAIL_ADDRESS) {
+    redirect('/');
+  }
+
+  const userId = session!.user!.id;
+
+  const leagueQuery = await sql.query<{ league_id: number }>(
+    `SELECT league_id FROM user_leagues WHERE user_id = $1`,
+    [userId]
+  );
+  const leagueId = leagueQuery.rows[0]?.league_id;
+
+  if (!leagueId) redirect('/');
+
+  let fplData: any = null;
+  let allFixtures: any[] = [];
+
+  try {
+    const [fplRes, fixturesRes] = await Promise.all([
+      fetch('https://fantasy.premierleague.com/api/bootstrap-static/'),
+      fetch('https://fantasy.premierleague.com/api/fixtures')
+    ]);
+
+    if (!fplRes.ok || !fixturesRes.ok)
+      throw new Error('FPL API returned non-OK status');
+
+    [fplData, allFixtures] = await Promise.all([
+      fplRes.json(),
+      fixturesRes.json()
+    ]);
+  } catch {
+    return (
+      <main className="p-6">
+        <p className="text-red-500">
+          Failed to load fixture data from the FPL API. Please refresh the page.
+        </p>
+      </main>
+    );
+  }
+
+  if (!fplData?.teams || !Array.isArray(allFixtures)) {
+    return (
+      <main className="p-6">
+        <p className="text-red-500">
+          Failed to load fixture data from the FPL API. Please refresh the page.
+        </p>
+      </main>
+    );
+  }
+
+  const [participantsQuery, gameQuery] = await Promise.all([
+    sql.query<Participant>(
+      `SELECT u.id, u.name, u.email
+       FROM users u
+       JOIN user_leagues ul ON u.id = ul.user_id
+       WHERE ul.league_id = $1
+       ORDER BY u.name`,
+      [leagueId]
+    ),
+    sql.query<{ game_id: number }>(
+      `SELECT MAX(id) AS game_id FROM games WHERE league_id = $1`,
+      [leagueId]
+    )
+  ]);
+
+  const currentGameId = gameQuery.rows[0]?.game_id;
+
+  if (!currentGameId) {
+    return (
+      <main className="p-6">
+        <p className="text-muted-foreground">
+          No active game found for this league.
+        </p>
+      </main>
+    );
+  }
+
+  const predictionsQuery = await sql.query<AdminPrediction>(
+    `SELECT user_id, team_selected, team_opposing, team_selected_location,
+            result_selected, correct, fpl_gw, round_number, prediction_submitted_time
+     FROM results
+     WHERE game_id = $1
+     ORDER BY user_id, round_number ASC`,
+    [currentGameId]
+  );
+
+  const teamsArr: { id: number; name: string; short_name: string }[] =
+    fplData.teams.map(
+      ({
+        id,
+        name,
+        short_name
+      }: {
+        id: number;
+        name: string;
+        short_name: string;
+      }) => ({
+        id,
+        name,
+        short_name
+      })
+    );
+
+  const currentGwNumber: number =
+    fplData.events.find(
+      (e: { is_current: boolean; id: number }) => e.is_current
+    )?.id ?? MIN_GW;
+
+  const predictionWeekFixtures = allFixtures.filter(
+    (f: { event: number }) => f.event === currentGwNumber + 1
+  );
+
+  return (
+    <main>
+      <AdminInputForm
+        participants={participantsQuery.rows}
+        existingPredictions={predictionsQuery.rows}
+        teamsArr={teamsArr}
+        predictionWeekFixtures={predictionWeekFixtures}
+        currentGwNumber={currentGwNumber}
+        currentGameId={currentGameId}
+      />
+    </main>
+  );
+}

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import {
+  ClipboardList,
   Home,
   LineChart,
   MousePointerClickIcon,
@@ -90,6 +91,13 @@ async function DesktopNav() {
         {/* <NavItem href="#" label="Analytics">
           <LineChart className="h-5 w-5" />
         </NavItem> */}
+
+        {!!process.env.NEXT_PUBLIC_MY_EMAIL_ADDRESS &&
+          session?.user?.email === process.env.NEXT_PUBLIC_MY_EMAIL_ADDRESS && (
+            <NavItem href="/admin" label="Admin">
+              <ClipboardList className="h-5 w-5" />
+            </NavItem>
+          )}
       </nav>
       <nav className="mt-auto flex flex-col items-center gap-4 px-2 sm:py-5">
         <Tooltip>

--- a/app/(dashboard)/results/loading.tsx
+++ b/app/(dashboard)/results/loading.tsx
@@ -1,0 +1,34 @@
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+
+export default function ResultsLoading() {
+  return (
+    <Card className="rounded-xl bg-white shadow-sm animate-pulse">
+      <CardHeader className="p-4 md:p-6">
+        <div className="h-6 w-24 rounded-full bg-gray-200 mb-2" />
+        <div className="h-4 w-48 rounded-full bg-gray-200" />
+      </CardHeader>
+
+      <CardContent className="p-2 md:p-6 md:pt-0 overflow-x-auto">
+        {/* Table header */}
+        <div className="flex gap-4 mb-3 pb-3 border-b border-gray-100">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div key={i} className="h-4 w-20 rounded-full bg-gray-200" />
+          ))}
+        </div>
+
+        {/* Table rows */}
+        {Array.from({ length: 8 }).map((_, i) => (
+          <div key={i} className="flex gap-4 py-3 border-b border-gray-50">
+            <div className="h-4 w-16 rounded-full bg-gray-200" />
+            {Array.from({ length: 4 }).map((_, j) => (
+              <div key={j} className="flex flex-col gap-1">
+                <div className="h-4 w-20 rounded-full bg-gray-100" />
+                <div className="h-3 w-16 rounded-full bg-gray-100" />
+              </div>
+            ))}
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/api/admin/predictions/route.ts
+++ b/app/api/admin/predictions/route.ts
@@ -1,0 +1,156 @@
+import { auth } from '@/lib/auth';
+import { sql } from '@vercel/postgres';
+
+export async function POST(request: Request) {
+  try {
+    const session = await auth();
+
+    if (session?.user?.email !== process.env.NEXT_PUBLIC_MY_EMAIL_ADDRESS) {
+      return new Response(JSON.stringify({ error: 'Forbidden' }), {
+        status: 403,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+
+    const adminUserId = session!.user!.id;
+
+    const body = await request.json();
+    const {
+      target_user_id,
+      team_selected,
+      team_opposing,
+      team_selected_location,
+      result_selected,
+      fpl_gw,
+      round_number
+    } = body;
+
+    if (
+      !target_user_id ||
+      !team_selected ||
+      !team_opposing ||
+      !team_selected_location ||
+      !result_selected ||
+      !fpl_gw ||
+      !round_number
+    ) {
+      return new Response(
+        JSON.stringify({ error: 'Missing required fields' }),
+        {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' }
+        }
+      );
+    }
+
+    const { rows } = await sql.query(
+      `
+      WITH games_numbered AS (
+        SELECT
+          id AS game_id,
+          league_id,
+          ROW_NUMBER() OVER (PARTITION BY league_id ORDER BY id) AS game_number
+        FROM games
+      )
+      SELECT
+        game_id
+        , league_id
+        , game_number
+      FROM games_numbered
+      WHERE league_id = (
+        SELECT
+            league_id
+        FROM user_leagues
+        WHERE user_id = ($1)
+      )
+      ORDER BY game_id DESC
+      LIMIT 1;
+      `,
+      [target_user_id]
+    );
+
+    if (!rows || rows.length === 0) {
+      return new Response(
+        JSON.stringify({ error: 'User not part of a league' }),
+        {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' }
+        }
+      );
+    }
+
+    const { game_id, league_id } = rows[0];
+
+    const adminLeagueQuery = await sql.query<{ league_id: number }>(
+      `SELECT league_id FROM user_leagues WHERE user_id = $1`,
+      [adminUserId]
+    );
+    const adminLeagueId = adminLeagueQuery.rows[0]?.league_id;
+
+    if (!adminLeagueId || adminLeagueId !== league_id) {
+      return new Response(
+        JSON.stringify({ error: 'Target user is not in your league' }),
+        { status: 403, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const duplicateCheck = await sql.query(
+      `SELECT 1 FROM results WHERE user_id = $1 AND game_id = $2 AND fpl_gw = $3 LIMIT 1`,
+      [target_user_id, game_id, fpl_gw]
+    );
+
+    if (duplicateCheck.rows.length > 0) {
+      return new Response(
+        JSON.stringify({
+          error: 'Prediction already exists for this user and gameweek'
+        }),
+        { status: 409, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    await sql.query(
+      `
+        INSERT INTO results (
+            user_id
+            , game_id
+            , team_selected
+            , team_opposing
+            , team_selected_location
+            , result_selected
+            , correct
+            , fpl_gw
+            , round_number
+            , team_selected_score
+            , team_opposing_score
+            , league_id
+            , prediction_submitted_time
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13);`,
+      [
+        target_user_id,
+        game_id,
+        team_selected,
+        team_opposing,
+        team_selected_location,
+        result_selected,
+        null,
+        fpl_gw,
+        round_number,
+        null,
+        null,
+        league_id,
+        new Date().toISOString()
+      ]
+    );
+
+    return new Response(JSON.stringify('success'), {
+      status: 201,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  } catch (error) {
+    console.error('error in POST /api/admin/predictions', error);
+    return new Response(JSON.stringify({ error: 'Internal server error' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }
+}

--- a/lib/definitions.ts
+++ b/lib/definitions.ts
@@ -99,3 +99,21 @@ export type Injury = {
   news: string;
   team_name: FPLTeamName | null;
 };
+
+export type Participant = {
+  id: string;
+  name: string | null;
+  email: string | null;
+};
+
+export type AdminPrediction = {
+  user_id: string;
+  team_selected: string;
+  team_opposing: string;
+  team_selected_location: string;
+  result_selected: string;
+  correct: boolean | null;
+  fpl_gw: number | null;
+  round_number: number;
+  prediction_submitted_time: string | null;
+};


### PR DESCRIPTION
## Summary

- Adds a new `/admin` route (server component) guarded by email — only accessible when logged in as the admin account
- Displays all league participants in a table with their existing picks for the current game shown read-only, and input dropdowns for anyone who hasn't submitted yet
- Selecting a team auto-derives the opponent, home/away location, and FPL GW from the fixtures API — no manual data entry needed
- New `POST /api/admin/predictions` endpoint with full validation: auth guard, required field check, duplicate submission check (409), and cross-league write prevention
- Added `loading.tsx` skeletons for `/admin` and `/results` so navigation no longer looks like a crash
- Shared `Participant` and `AdminPrediction` types added to `lib/definitions.ts`

## Test plan

- [ ] Navigate to `/admin` when not logged in → redirected to `/`
- [ ] Navigate to `/admin` when logged in as a non-admin user → redirected to `/`
- [ ] Navigate to `/admin` as admin → page loads with participant table
- [ ] Admin nav icon only visible when logged in as the admin account
- [ ] Participants who have already submitted show a read-only grey badge (Home **v** Away with pick in bold)
- [ ] Previous picks show green/red/grey based on correctness
- [ ] Selecting a team with no fixture in the prediction GW → Save button stays disabled
- [ ] Selecting a valid team → opponent and home/away auto-populates; Save enabled after choosing outcome
- [ ] Submitting a prediction → row goes read-only immediately; record appears in Neon DB
- [ ] Submitting twice for the same user/GW via the API → 409 returned
- [ ] Navigating to `/admin` or `/results` shows a pulsing skeleton immediately rather than a blank screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)