### PR TITLE
Feature/wc group stage

### DIFF
--- a/app/(dashboard)/fixtures-results.tsx
+++ b/app/(dashboard)/fixtures-results.tsx
@@ -13,7 +13,7 @@ import {
 import { Loader } from 'lucide-react';
 import { FixturesData } from '@/lib/definitions';
 import { TeamForm } from '@/components/TeamForm';
-import { TeamsArr } from './page';
+import { TeamsArr } from '@/lib/definitions';
 import { MAX_GW, MIN_GW } from '@/lib/constants';
 import {
   groupFixturesByDate,

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -82,7 +82,7 @@ async function DesktopNav() {
           <Home className="h-5 w-5" />
         </NavItem>
 
-        <NavItem href="/results" label="Results">
+        <NavItem href="/results" label="Results" disabled>
           <Table className="h-5 w-5" />
         </NavItem>
 
@@ -95,18 +95,9 @@ async function DesktopNav() {
         </NavItem> */}
       </nav>
       <nav className="mt-auto flex flex-col items-center gap-4 px-2 sm:py-5">
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Link
-              href="#"
-              className="flex h-9 w-9 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:text-foreground md:h-8 md:w-8"
-            >
-              <Settings className="h-5 w-5" />
-              <span className="sr-only">Settings</span>
-            </Link>
-          </TooltipTrigger>
-          <TooltipContent side="right">Settings</TooltipContent>
-        </Tooltip>
+        <NavItem href="/settings" label="Settings" disabled>
+          <Settings className="h-5 w-5" />
+        </NavItem>
 
         <AuthButtons />
       </nav>

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import {
+  BookOpen,
   Home,
   LineChart,
   MousePointerClickIcon,
@@ -9,6 +10,7 @@ import {
   Settings,
   ShoppingCart,
   Table,
+  Trophy,
   Users2
 } from 'lucide-react';
 
@@ -68,25 +70,26 @@ async function DesktopNav() {
     <aside className="fixed inset-y-0 left-0 z-10 hidden w-14 flex-col border-r bg-background sm:flex">
       <nav className="flex flex-col items-center gap-4 px-2 sm:py-5">
         <Link
-          href="/landing"
+          href="/"
           className="group flex h-9 w-9 shrink-0 items-center justify-center gap-2 rounded-full bg-primary text-lg font-semibold text-primary-foreground md:h-8 md:w-8 md:text-base"
         >
-          <VercelLogo className="h-3 w-3 transition-all group-hover:scale-110" />
-          <span className="sr-only">Acme Inc</span>
+          <Trophy className="h-4 w-4 transition-all group-hover:scale-110" />
+          <span className="sr-only">LPS</span>
         </Link>
 
-        <NavItem href="/" label="Dashboard">
+        {/* World Cup 2026 nav */}
+        <NavItem href="/" label="Picks">
           <Home className="h-5 w-5" />
         </NavItem>
-
-        {/* <NavItem href="#" label="Predictions">
-          <MousePointerClickIcon className="h-5 w-5" />
-        </NavItem> */}
 
         <NavItem href="/results" label="Results">
           <Table className="h-5 w-5" />
         </NavItem>
 
+        {/* FPL nav (restore after summer) */}
+        {/* <NavItem href="#" label="Predictions">
+          <MousePointerClickIcon className="h-5 w-5" />
+        </NavItem> */}
         {/* <NavItem href="#" label="Analytics">
           <LineChart className="h-5 w-5" />
         </NavItem> */}
@@ -123,26 +126,21 @@ function MobileNav() {
       <SheetContent side="left" className="sm:max-w-xs">
         <nav className="grid gap-6 text-lg font-medium">
           <Link
-            href="/landing"
+            href="/"
             className="group flex h-10 w-10 shrink-0 items-center justify-center gap-2 rounded-full bg-primary text-lg font-semibold text-primary-foreground md:text-base"
           >
-            <Package2 className="h-5 w-5 transition-all group-hover:scale-110" />
-            <span className="sr-only">Vercel</span>
+            <Trophy className="h-5 w-5 transition-all group-hover:scale-110" />
+            <span className="sr-only">LPS</span>
           </Link>
+
+          {/* World Cup 2026 nav */}
           <Link
             href="/"
             className="flex items-center gap-4 px-2.5 text-muted-foreground hover:text-foreground"
           >
             <Home className="h-5 w-5" />
-            Dashboard
+            Picks
           </Link>
-          {/* <Link
-            href="#"
-            className="flex items-center gap-4 px-2.5 text-muted-foreground hover:text-foreground"
-          >
-            <MousePointerClickIcon className="h-5 w-5" />
-            Predictions
-          </Link> */}
           <Link
             href="/results"
             className="flex items-center gap-4 px-2.5 text-muted-foreground hover:text-foreground"
@@ -151,13 +149,15 @@ function MobileNav() {
             Results
           </Link>
 
-          <Link
-            href="#"
-            className="flex items-center gap-4 px-2.5 text-muted-foreground hover:text-foreground"
-          >
+          {/* FPL nav (restore after summer) */}
+          {/* <Link href="#" className="flex items-center gap-4 px-2.5 text-muted-foreground hover:text-foreground">
+            <MousePointerClickIcon className="h-5 w-5" />
+            Predictions
+          </Link> */}
+          {/* <Link href="#" className="flex items-center gap-4 px-2.5 text-muted-foreground hover:text-foreground">
             <LineChart className="h-5 w-5" />
             Settings
-          </Link>
+          </Link> */}
         </nav>
       </SheetContent>
     </Sheet>

--- a/app/(dashboard)/league-table.tsx
+++ b/app/(dashboard)/league-table.tsx
@@ -10,7 +10,7 @@ import {
   TableRow
 } from '@/components/ui/table';
 import { FixturesData, FPLTeamName } from '@/lib/definitions';
-import { TeamsArr } from './page';
+import { TeamsArr } from '@/lib/definitions';
 import { CircleCheck, CircleMinus, CircleX, Loader } from 'lucide-react';
 
 type LeagueTableRow = {

--- a/app/(dashboard)/nav-item.tsx
+++ b/app/(dashboard)/nav-item.tsx
@@ -12,29 +12,40 @@ import { usePathname } from 'next/navigation';
 export function NavItem({
   href,
   label,
-  children
+  children,
+  disabled = false
 }: {
   href: string;
   label: string;
   children: React.ReactNode;
+  disabled?: boolean;
 }) {
   const pathname = usePathname();
 
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <Link
-          href={href}
-          className={clsx(
-            'flex h-9 w-9 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:text-foreground md:h-8 md:w-8',
-            {
-              'bg-accent text-black': pathname === href
-            }
-          )}
-        >
-          {children}
-          <span className="sr-only">{label}</span>
-        </Link>
+        {disabled ? (
+          <span
+            className="flex h-9 w-9 items-center justify-center rounded-lg text-muted-foreground opacity-30 cursor-not-allowed md:h-8 md:w-8"
+          >
+            {children}
+            <span className="sr-only">{label}</span>
+          </span>
+        ) : (
+          <Link
+            href={href}
+            className={clsx(
+              'flex h-9 w-9 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:text-foreground md:h-8 md:w-8',
+              {
+                'bg-accent text-black': pathname === href
+              }
+            )}
+          >
+            {children}
+            <span className="sr-only">{label}</span>
+          </Link>
+        )}
       </TooltipTrigger>
       <TooltipContent side="right">{label}</TooltipContent>
     </Tooltip>

--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -6,7 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import WcPicksForm from './wc-picks-form';
 import useWcFixtures from 'app/hooks/useWcFixtures';
 import useWcPicks from 'app/hooks/useWcPicks';
-import { WC_ROUND_DEADLINES, WC_ROUND_LABELS } from '@/lib/wc-constants';
+import { WC_ROUND_DEADLINES, WC_ROUND_FIXTURE_LABELS } from '@/lib/wc-constants';
 
 // ─── FPL Last Player Standing (commented out for WC summer) ──────────────────
 // import { useEffect, useMemo, useState } from 'react';
@@ -97,72 +97,118 @@ const Page = () => {
 
         {/* ── Rules tab ──────────────────────────────────────────────────── */}
         <TabsContent value="rules">
-          <Card className="rounded-xl bg-white shadow-sm">
-            <CardHeader className="p-6 pb-2">
-              <CardTitle className="text-xl">How to play</CardTitle>
-            </CardHeader>
-            <CardContent className="p-6 pt-4 flex flex-col gap-6 text-sm text-gray-700 leading-relaxed">
+          <div className="flex flex-col gap-6 text-sm text-gray-700 leading-relaxed">
 
-              <section>
-                <h3 className="font-semibold text-base text-gray-900 mb-2">The basics</h3>
+            {/* Badges + intro */}
+            <Card className="rounded-xl bg-white shadow-sm">
+              <CardContent className="p-6 flex flex-col gap-4">
+                <div className="flex flex-wrap gap-2">
+                  <span className="px-3 py-1 rounded-full bg-amber-400 text-white text-xs font-semibold">£10 entry</span>
+                  <span className="px-3 py-1 rounded-full bg-gray-800 text-white text-xs font-semibold">Winner takes all</span>
+                  <span className="px-3 py-1 rounded-full bg-gray-800 text-white text-xs font-semibold">11 rounds</span>
+                </div>
                 <p>
-                  This is a <strong>Last Player Standing</strong> game for the World Cup 2026 group stage. There are <strong>6 rounds</strong>. Each round, you pick one team to <strong>win their match outright</strong> — draws don&apos;t count. Get it right and you survive; get it wrong and you&apos;re out.
+                  The game has two phases — a <strong>Last Player Standing group stage</strong> followed by a{' '}
+                  <strong>points-based score prediction knockout stage</strong> (like Super 6). Here&apos;s how it works.
                 </p>
-              </section>
+              </CardContent>
+            </Card>
 
-              <section>
-                <h3 className="font-semibold text-base text-gray-900 mb-2">The no-repeat rule</h3>
+            {/* Phase 1 */}
+            <Card className="rounded-xl bg-white shadow-sm overflow-hidden">
+              <div className="border-l-4 border-amber-400 px-6 py-4 bg-amber-50">
+                <p className="text-xs font-bold tracking-widest text-amber-600 uppercase mb-0.5">Phase 1 · Rounds 1–6</p>
+                <h3 className="text-lg font-bold text-gray-900">The Group Stage</h3>
+              </div>
+              <CardContent className="p-6 flex flex-col gap-4">
                 <p>
-                  You <strong>cannot pick the same team twice</strong> across all 6 rounds. Once you&apos;ve used a team, they&apos;re gone from your options for the rest of the group stage. Choose wisely.
+                  The group stage is split into 6 rounds. Each round, pick a team to <strong>win</strong> from that round&apos;s fixtures. Incorrect prediction? Eliminated. Standard LPS stuff.
                 </p>
-              </section>
-
-              <section>
-                <h3 className="font-semibold text-base text-gray-900 mb-2">How the rounds work</h3>
-                <p className="mb-2">
-                  The 6 rounds follow the group stage matchdays, alternating between two halves of the draw:
-                </p>
-                <ul className="flex flex-col gap-1 pl-1">
-                  {[1, 2, 3, 4, 5, 6].map((r) => (
-                    <li key={r} className="flex items-start gap-2">
-                      <span className="font-semibold text-gray-500 shrink-0 w-5 text-right">{r}.</span>
-                      <span>{WC_ROUND_LABELS[r]}</span>
-                    </li>
-                  ))}
-                </ul>
-              </section>
-
-              <section>
-                <h3 className="font-semibold text-base text-gray-900 mb-2">Submitting your picks</h3>
                 <p>
-                  You can submit all 6 predictions upfront — you don&apos;t have to wait for each round to finish. You can also come back and change any pick up to the deadline for that round. Once the deadline passes, your pick is locked.
+                  You can submit all 6 picks upfront and amend them right up to each round&apos;s deadline.
                 </p>
-              </section>
 
-              <section>
-                <h3 className="font-semibold text-base text-gray-900 mb-2">Deadlines</h3>
-                <ul className="flex flex-col gap-1 pl-1">
-                  {[1, 2, 3, 4, 5, 6].map((r) => (
-                    <li key={r} className="flex items-start gap-2">
-                      <span className="font-semibold text-gray-500 shrink-0 w-5 text-right">{r}.</span>
-                      <span>
-                        <span className="font-medium">Round {r}:</span>{' '}
-                        {formatDeadline(WC_ROUND_DEADLINES[r])}
-                      </span>
-                    </li>
-                  ))}
-                </ul>
-              </section>
+                {/* Round table */}
+                <div className="rounded-lg border border-gray-200 overflow-hidden">
+                  <table className="w-full text-xs">
+                    <thead>
+                      <tr className="bg-gray-50 border-b border-gray-200">
+                        <th className="text-left px-4 py-2.5 font-semibold text-gray-500 uppercase tracking-wide w-16">Round</th>
+                        <th className="text-left px-4 py-2.5 font-semibold text-gray-500 uppercase tracking-wide">Fixtures</th>
+                        <th className="text-right px-4 py-2.5 font-semibold text-gray-500 uppercase tracking-wide">Deadline</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {[1, 2, 3, 4, 5, 6].map((r) => (
+                        <tr key={r} className="border-b border-gray-100 last:border-0">
+                          <td className="px-4 py-3 font-semibold text-gray-800">{r}</td>
+                          <td className="px-4 py-3 text-gray-700">{WC_ROUND_FIXTURE_LABELS[r]}</td>
+                          <td className="px-4 py-3 text-right text-gray-500 whitespace-nowrap">{formatDeadline(WC_ROUND_DEADLINES[r])}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
 
-              <section>
-                <h3 className="font-semibold text-base text-gray-900 mb-2">Knockout stage</h3>
+                {/* No duplicate callout */}
+                <div className="rounded-lg bg-amber-50 border border-amber-200 px-4 py-3">
+                  <p>
+                    <strong className="text-amber-800">No duplicate teams:</strong>{' '}
+                    <span className="text-amber-700">you can&apos;t pick the same team more than once across your 6 group stage picks.</span>
+                  </p>
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Phase 2 */}
+            <Card className="rounded-xl bg-white shadow-sm overflow-hidden">
+              <div className="border-l-4 border-green-500 px-6 py-4 bg-green-50">
+                <p className="text-xs font-bold tracking-widest text-green-600 uppercase mb-0.5">Phase 2 · Rounds 7–11</p>
+                <h3 className="text-lg font-bold text-gray-900">The Knockout Stage</h3>
+              </div>
+              <CardContent className="p-6 flex flex-col gap-4">
                 <p>
-                  Players who survive all 6 group stage rounds advance to the knockout phase. That&apos;s a separate points-based game where everyone predicts the score of each knockout fixture — 5 points for the correct score, 2 points for the correct result. More details coming once the group stage is complete.
+                  Survive the group stage and you&apos;re into the knockout phase. You can now{' '}
+                  <strong>pick any team again</strong> — the no-repeat rule no longer applies. Each knockout round you predict the score of <strong>any match</strong> in that round. Points stack up and the highest total after The Final wins.
                 </p>
-              </section>
 
-            </CardContent>
-          </Card>
+                {/* Points cards */}
+                <div className="grid grid-cols-2 gap-3">
+                  <div className="rounded-lg border-2 border-green-200 bg-green-50 p-4 text-center">
+                    <p className="text-2xl font-bold text-green-700">5 pts</p>
+                    <p className="text-xs text-green-600 mt-0.5">Correct score</p>
+                  </div>
+                  <div className="rounded-lg border-2 border-amber-200 bg-amber-50 p-4 text-center">
+                    <p className="text-2xl font-bold text-amber-700">2 pts</p>
+                    <p className="text-xs text-amber-600 mt-0.5">Correct result</p>
+                  </div>
+                </div>
+
+                {/* Knockout round table */}
+                <div className="rounded-lg border border-gray-200 overflow-hidden">
+                  <table className="w-full text-xs">
+                    <thead>
+                      <tr className="bg-gray-50 border-b border-gray-200">
+                        <th className="text-left px-4 py-2.5 font-semibold text-gray-500 uppercase tracking-wide w-16">Round</th>
+                        <th className="text-left px-4 py-2.5 font-semibold text-gray-500 uppercase tracking-wide">Fixtures</th>
+                        <th className="text-right px-4 py-2.5 font-semibold text-gray-500 uppercase tracking-wide">Deadline</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {[7, 8, 9, 10, 11].map((r) => (
+                        <tr key={r} className={`border-b border-gray-100 last:border-0 ${r === 11 ? 'bg-amber-50' : ''}`}>
+                          <td className={`px-4 py-3 font-semibold ${r === 11 ? 'text-amber-700' : 'text-gray-800'}`}>{r}</td>
+                          <td className={`px-4 py-3 ${r === 11 ? 'font-semibold text-amber-700' : 'text-gray-700'}`}>{WC_ROUND_FIXTURE_LABELS[r]}</td>
+                          <td className={`px-4 py-3 text-right whitespace-nowrap ${r === 11 ? 'text-amber-600' : 'text-gray-500'}`}>{formatDeadline(WC_ROUND_DEADLINES[r])}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </CardContent>
+            </Card>
+
+          </div>
         </TabsContent>
 
         {/* ── Group Stage tab ────────────────────────────────────────────── */}

--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -107,10 +107,24 @@ const Page = () => {
                   <span className="px-3 py-1 rounded-full bg-gray-800 text-white text-xs font-semibold">Winner takes all</span>
                   <span className="px-3 py-1 rounded-full bg-gray-800 text-white text-xs font-semibold">11 rounds</span>
                 </div>
-                <p>
-                  The game has two phases — a <strong>Last Player Standing group stage</strong> followed by a{' '}
-                  <strong>points-based score prediction knockout stage</strong> (like Super 6). Here&apos;s how it works.
-                </p>
+                <p>The game has two phases:</p>
+                <ol className="flex flex-col gap-3">
+                  <li className="flex gap-3">
+                    <span className="font-bold text-gray-400 shrink-0 w-4">1</span>
+                    <div>
+                      <p className="font-semibold text-gray-900">Group Stage — Last Player Standing style</p>
+                      <p className="text-muted-foreground text-xs mt-0.5">Predict 6 teams to win, incorrect prediction? You&apos;re eliminated. Standard LPS stuff.</p>
+                    </div>
+                  </li>
+                  <li className="flex gap-3">
+                    <span className="font-bold text-gray-400 shrink-0 w-4">2</span>
+                    <div>
+                      <p className="font-semibold text-gray-900">Knockout Stage — Score Prediction</p>
+                      <p className="text-muted-foreground text-xs mt-0.5">Predict the score of a predefined knockout stage match. Earn 5 points for the correct score and 2 points for the correct outcome. Highest points total after The Final wins the pot!</p>
+                    </div>
+                  </li>
+                </ol>
+                <p className="text-muted-foreground text-xs">Details below...</p>
               </CardContent>
             </Card>
 
@@ -124,7 +138,7 @@ const Page = () => {
                 <p>
                   The group stage is split into 6 rounds. Each round, pick a team to <strong>win</strong> from that round&apos;s fixtures. Incorrect prediction? Eliminated. Standard LPS stuff.
                 </p>
-                <p>
+                <p className="text-muted-foreground">
                   You can submit all 6 picks upfront and amend them right up to each round&apos;s deadline.
                 </p>
 
@@ -168,7 +182,7 @@ const Page = () => {
               </div>
               <CardContent className="p-6 flex flex-col gap-4">
                 <p>
-                  Survive the group stage and you&apos;re into the knockout phase. Everyone still in predicts the score of the <strong>same match</strong> each round — the last fixture played in that round. No team restrictions apply; you can pick freely. Points stack up and the highest total after The Final wins.
+                  Survive the group stage and you&apos;re in with a shot at winning. Each knockout round, everyone predicts the score of the same match. Points accumulate and the highest total after The Final takes the pot.
                 </p>
 
                 {/* Points cards */}

--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -168,8 +168,7 @@ const Page = () => {
               </div>
               <CardContent className="p-6 flex flex-col gap-4">
                 <p>
-                  Survive the group stage and you&apos;re into the knockout phase. You can now{' '}
-                  <strong>pick any team again</strong> — the no-repeat rule no longer applies. Each knockout round you predict the score of <strong>any match</strong> in that round. Points stack up and the highest total after The Final wins.
+                  Survive the group stage and you&apos;re into the knockout phase. Everyone still in predicts the score of the <strong>same match</strong> each round — the last fixture played in that round. No team restrictions apply; you can pick freely. Points stack up and the highest total after The Final wins.
                 </p>
 
                 {/* Points cards */}
@@ -230,7 +229,10 @@ const Page = () => {
               <p className="text-4xl">🏆</p>
               <p className="text-lg font-semibold text-gray-800">Knockout stage — coming soon</p>
               <p className="text-sm text-muted-foreground max-w-sm">
-                Once the group stage is complete, surviving players will predict the scores of the knockout fixtures. Check back after 27 June.
+                Everyone who survives the group stage will predict the score of the same match each round — the last fixture played in that round. 5 points for a correct score, 2 for the correct result. The highest points total after The Final wins.
+              </p>
+              <p className="text-sm text-muted-foreground max-w-sm">
+                Check back after 27 June when the group stage is complete.
               </p>
             </CardContent>
           </Card>

--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -39,6 +39,12 @@ import { WC_ROUND_DEADLINES, WC_ROUND_FIXTURE_LABELS } from '@/lib/wc-constants'
 // import useCurrentGameData from 'app/hooks/useCurrentGameData';
 // import Injuries from './injuries';
 
+// export type TeamsArr = {
+//   id: number;
+//   name: FPLTeamName;
+//   short_name: string;
+// }[];
+
 function formatDeadline(date: Date): string {
   return date.toLocaleString('en-GB', {
     timeZone: 'Europe/London',
@@ -254,7 +260,120 @@ const Page = () => {
       </Tabs>
 
       {/* ── FPL dashboard (commented out for the summer) ─────────────────── */}
-      {/* ... restore by uncommenting the imports at the top ...              */}
+      {/* Restore by: uncommenting imports at the top, removing WC tabs above, */}
+      {/* and uncommenting the block below.                                     */}
+      {/*
+      <div className="grid gap-6 grid-cols-1 md:grid-cols-4 my-6">
+        <div className="w-full grid md:col-span-3">
+          <CurrentGame
+            currentGameResults={currentGameResults}
+            leagueName={leagueName}
+            isLoading={isLoadingLeagueName || isLoadingCurrentGameData}
+          />
+        </div>
+        <div className="w-full md:col-span-1">
+          <Predictions
+            session={session}
+            teamsArr={teamsArr}
+            results={results}
+            predictionWeekFixtures={predictionWeekFixtures}
+            setRefreshTrigger={setRefreshTrigger}
+            isLoading={isLoadingResults || isLoadingFplData}
+            currentGameId={currentGameId}
+          />
+        </div>
+      </div>
+      <div className="grid gap-6 grid-cols-1 md:grid-cols-4 my-6">
+        <div className="w-full md:col-span-2 relative">
+          <div className="flex flex-col gap-6 md:absolute md:inset-0">
+            <FixturesResults
+              fixtures={fixtures}
+              currentGwNumber={currentGwNumber}
+              teamsArr={teamsArr}
+              isLoading={isLoadingFixtures}
+            />
+            <div className="flex-1 min-h-0 flex flex-col">
+              <Injuries data={injuries} isLoading={isLoadingFplData} />
+            </div>
+          </div>
+        </div>
+        <div className="w-full md:col-span-2">
+          <LeagueTable
+            fixtures={fixtures}
+            isLoading={isLoadingFixtures}
+            teamsArr={teamsArr}
+          />
+        </div>
+      </div>
+      <div className="w-full overflow-x-auto my-6">
+        <PickPlanner
+          teams={teamsArr}
+          fixtures={fixtures || []}
+          currentGwNumber={currentGwNumber}
+          numWeeks={numWeeks}
+          setNumWeeks={setNumWeeks}
+          results={results || {}}
+          session={session}
+          currentGameId={currentGameId}
+        />
+      </div>
+      <Card className="rounded-xl bg-white p-2 my-6 shadow-sm overflow-auto md:hidden">
+        <CardHeader className="p-2 md:p-6">
+          <CardTitle>Results</CardTitle>
+          <CardDescription>View your previous results</CardDescription>
+        </CardHeader>
+        <CardContent className="p-2 md:p-6 md:pt-0">
+          {session === null ? (
+            <div style={{ display: 'flex', justifyContent: 'center' }}>
+              <a
+                style={{ color: 'blue', fontWeight: 600, textAlign: 'center' }}
+                href="/api/auth/signin"
+              >
+                Sign in to get started
+              </a>
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Game</TableHead>
+                  {Array.from(Array(maxGameWeeks)).map((_, gameWeek) => (
+                    <TableHead key={`gw-headcell-${gameWeek + 1}`}>
+                      {`Round ${gameWeek + 1}`}
+                    </TableHead>
+                  ))}
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {Object.values(results).map((gameResults, gameIdx) => (
+                  <TableRow key={`game-row-${gameResults[0].game_id}`}>
+                    <TableCell className="font-medium">{gameIdx + 1}</TableCell>
+                    {gameResults.map((prediction, predictionIdx) => (
+                      <TableCell
+                        key={`gw-cell-${gameIdx}-${predictionIdx}`}
+                        className={`table-cell ${prediction.correct ? 'bg-green-200' : 'bg-red-200'}`}
+                      >
+                        <div style={{ display: 'flex', flexDirection: 'column', textAlign: 'center' }}>
+                          <div>
+                            <TeamName location="Home" prediction={prediction} /> v{' '}
+                            <TeamName location="Away" prediction={prediction} />
+                          </div>
+                          <div>
+                            <TeamScore location="Home" prediction={prediction} />{' '}
+                            <span className="font-thin">v</span>{' '}
+                            <TeamScore location="Away" prediction={prediction} />
+                          </div>
+                        </div>
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+      */}
     </main>
   );
 };

--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -80,8 +80,7 @@ const Page = () => {
           ⚽ World Cup 2026
         </h1>
         <p className="text-center text-xl font-light italic px-4 py-2">
-          Last Player Standing — pick a team to win each round. Use the same
-          team twice and you&apos;re out.
+          Survive the group stage then accumulate the most points to win.
         </p>
       </div>
 

--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -133,6 +133,8 @@ function RegisterInterestCard() {
             <p className="text-xs text-muted-foreground">
               Already have an account?{' '}
               <a href="/api/auth/signin" className="text-blue-600 underline">Sign in</a>
+              {' · '}
+              <a href="/privacy" target="_blank" rel="noopener noreferrer" className="underline">Privacy policy</a>
             </p>
           </>
         ) : (

--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -3,6 +3,9 @@
 import { useState } from 'react';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Loader } from 'lucide-react';
+import { useSession } from 'next-auth/react';
 import WcPicksForm from './wc-picks-form';
 import useWcFixtures from 'app/hooks/useWcFixtures';
 import useWcPicks from 'app/hooks/useWcPicks';
@@ -56,6 +59,99 @@ function formatDeadline(date: Date): string {
   });
 }
 
+function RegisterInterestCard() {
+  const { data: session, status } = useSession();
+  const [email, setEmail] = useState('');
+  const [submitStatus, setSubmitStatus] = useState<'idle' | 'submitting' | 'success' | 'error'>('idle');
+  const [errorMsg, setErrorMsg] = useState('');
+
+  // Don't show anything while session is loading or if already signed in
+  if (status === 'loading' || session) return null;
+
+  const registrationOpen = new Date() < WC_ROUND_DEADLINES[1];
+
+  const handleRegister = async () => {
+    setSubmitStatus('submitting');
+    setErrorMsg('');
+    try {
+      const res = await fetch('/api/wc/register-interest', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email })
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || 'Something went wrong.');
+      }
+      setSubmitStatus('success');
+    } catch (err: unknown) {
+      setErrorMsg(err instanceof Error ? err.message : 'Something went wrong.');
+      setSubmitStatus('error');
+    }
+  };
+
+  return (
+    <Card className="rounded-xl bg-white shadow-sm">
+      <CardContent className="p-6 flex flex-col gap-4">
+        {registrationOpen ? (
+          <>
+            <div>
+              <p className="font-semibold text-gray-900">Want to play?</p>
+              <p className="text-sm text-muted-foreground mt-0.5">
+                Register your interest and you&apos;ll be added to the game before the deadline.
+              </p>
+            </div>
+            {submitStatus === 'success' ? (
+              <div className="rounded-lg bg-green-50 border border-green-200 px-4 py-3 text-green-700 text-sm font-medium">
+                Request sent! You&apos;ll hear back before the deadline.
+              </div>
+            ) : (
+              <div className="flex gap-2">
+                <input
+                  type="email"
+                  placeholder="your@email.com"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  className="flex-1 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+                <Button
+                  onClick={handleRegister}
+                  disabled={submitStatus === 'submitting' || !email.includes('@')}
+                  size="sm"
+                >
+                  {submitStatus === 'submitting' ? (
+                    <Loader className="animate-spin h-4 w-4" />
+                  ) : (
+                    'Register interest'
+                  )}
+                </Button>
+              </div>
+            )}
+            {submitStatus === 'error' && (
+              <p className="text-red-600 text-xs">{errorMsg}</p>
+            )}
+            <p className="text-xs text-muted-foreground">
+              Already have an account?{' '}
+              <a href="/api/auth/signin" className="text-blue-600 underline">Sign in</a>
+            </p>
+          </>
+        ) : (
+          <>
+            <p className="font-semibold text-gray-900">Registration is closed</p>
+            <p className="text-sm text-muted-foreground">
+              The game has already started and new registrations are no longer being accepted.
+            </p>
+            <p className="text-xs text-muted-foreground">
+              Already have an account?{' '}
+              <a href="/api/auth/signin" className="text-blue-600 underline">Sign in</a>
+            </p>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
 const Page = () => {
   const [activeTab, setActiveTab] = useState('rules');
   const [refreshTrigger, setRefreshTrigger] = useState(0);
@@ -104,6 +200,9 @@ const Page = () => {
         {/* ── Rules tab ──────────────────────────────────────────────────── */}
         <TabsContent value="rules">
           <div className="flex flex-col gap-6 text-sm text-gray-700 leading-relaxed">
+
+            {/* Register interest — only shown to guests */}
+            <RegisterInterestCard />
 
             {/* Badges + intro */}
             <Card className="rounded-xl bg-white shadow-sm">

--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -1,7 +1,12 @@
 'use client';
 
-// ─── World Cup 2026 ───────────────────────────────────────────────────────────
+import { useState } from 'react';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import WcPicksForm from './wc-picks-form';
+import useWcFixtures from 'app/hooks/useWcFixtures';
+import useWcPicks from 'app/hooks/useWcPicks';
+import { WC_ROUND_DEADLINES, WC_ROUND_LABELS } from '@/lib/wc-constants';
 
 // ─── FPL Last Player Standing (commented out for WC summer) ──────────────────
 // import { useEffect, useMemo, useState } from 'react';
@@ -12,11 +17,7 @@ import WcPicksForm from './wc-picks-form';
 // import LeagueTable from './league-table';
 // import PickPlanner from '@/components/PickPlanner';
 // import {
-//   Card,
-//   CardContent,
 //   CardDescription,
-//   CardHeader,
-//   CardTitle
 // } from '@/components/ui/card';
 // import {
 //   Table,
@@ -38,13 +39,32 @@ import WcPicksForm from './wc-picks-form';
 // import useCurrentGameData from 'app/hooks/useCurrentGameData';
 // import Injuries from './injuries';
 
-// export type TeamsArr = {
-//   id: number;
-//   name: FPLTeamName;
-//   short_name: string;
-// }[];
+function formatDeadline(date: Date): string {
+  return date.toLocaleString('en-GB', {
+    timeZone: 'Europe/London',
+    weekday: 'short',
+    day: 'numeric',
+    month: 'short',
+    hour: '2-digit',
+    minute: '2-digit'
+  });
+}
 
 const Page = () => {
+  const [refreshTrigger, setRefreshTrigger] = useState(0);
+  const { wcFixtures, isLoadingWcFixtures } = useWcFixtures();
+  const { wcPicks, isLoadingWcPicks } = useWcPicks({ refreshTrigger });
+
+  // Amber dot: any open round (deadline not passed) has no saved pick
+  const now = new Date();
+  const showGroupStageIndicator =
+    !isLoadingWcPicks &&
+    [1, 2, 3, 4, 5, 6].some(
+      (r) =>
+        now < WC_ROUND_DEADLINES[r] &&
+        !wcPicks.some((p) => p.round_number === r)
+    );
+
   return (
     <main>
       {/* ── Hero ─────────────────────────────────────────────────────────── */}
@@ -58,124 +78,121 @@ const Page = () => {
         </p>
       </div>
 
-      {/* ── Picks form ───────────────────────────────────────────────────── */}
-      <WcPicksForm />
+      {/* ── Tabs ─────────────────────────────────────────────────────────── */}
+      <Tabs defaultValue="rules" className="w-full">
+        <TabsList className="w-full mb-4">
+          <TabsTrigger value="rules" className="flex-1">
+            Rules
+          </TabsTrigger>
+          <TabsTrigger value="group-stage" className="flex-1">
+            Group Stage
+            {showGroupStageIndicator && (
+              <span className="ml-1.5 h-2 w-2 rounded-full bg-amber-400 inline-block" />
+            )}
+          </TabsTrigger>
+          <TabsTrigger value="knockout" className="flex-1">
+            Knockout
+          </TabsTrigger>
+        </TabsList>
+
+        {/* ── Rules tab ──────────────────────────────────────────────────── */}
+        <TabsContent value="rules">
+          <Card className="rounded-xl bg-white shadow-sm">
+            <CardHeader className="p-6 pb-2">
+              <CardTitle className="text-xl">How to play</CardTitle>
+            </CardHeader>
+            <CardContent className="p-6 pt-4 flex flex-col gap-6 text-sm text-gray-700 leading-relaxed">
+
+              <section>
+                <h3 className="font-semibold text-base text-gray-900 mb-2">The basics</h3>
+                <p>
+                  This is a <strong>Last Player Standing</strong> game for the World Cup 2026 group stage. There are <strong>6 rounds</strong>. Each round, you pick one team to <strong>win their match outright</strong> — draws don&apos;t count. Get it right and you survive; get it wrong and you&apos;re out.
+                </p>
+              </section>
+
+              <section>
+                <h3 className="font-semibold text-base text-gray-900 mb-2">The no-repeat rule</h3>
+                <p>
+                  You <strong>cannot pick the same team twice</strong> across all 6 rounds. Once you&apos;ve used a team, they&apos;re gone from your options for the rest of the group stage. Choose wisely.
+                </p>
+              </section>
+
+              <section>
+                <h3 className="font-semibold text-base text-gray-900 mb-2">How the rounds work</h3>
+                <p className="mb-2">
+                  The 6 rounds follow the group stage matchdays, alternating between two halves of the draw:
+                </p>
+                <ul className="flex flex-col gap-1 pl-1">
+                  {[1, 2, 3, 4, 5, 6].map((r) => (
+                    <li key={r} className="flex items-start gap-2">
+                      <span className="font-semibold text-gray-500 shrink-0 w-5 text-right">{r}.</span>
+                      <span>{WC_ROUND_LABELS[r]}</span>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+
+              <section>
+                <h3 className="font-semibold text-base text-gray-900 mb-2">Submitting your picks</h3>
+                <p>
+                  You can submit all 6 predictions upfront — you don&apos;t have to wait for each round to finish. You can also come back and change any pick up to the deadline for that round. Once the deadline passes, your pick is locked.
+                </p>
+              </section>
+
+              <section>
+                <h3 className="font-semibold text-base text-gray-900 mb-2">Deadlines</h3>
+                <ul className="flex flex-col gap-1 pl-1">
+                  {[1, 2, 3, 4, 5, 6].map((r) => (
+                    <li key={r} className="flex items-start gap-2">
+                      <span className="font-semibold text-gray-500 shrink-0 w-5 text-right">{r}.</span>
+                      <span>
+                        <span className="font-medium">Round {r}:</span>{' '}
+                        {formatDeadline(WC_ROUND_DEADLINES[r])}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+
+              <section>
+                <h3 className="font-semibold text-base text-gray-900 mb-2">Knockout stage</h3>
+                <p>
+                  Players who survive all 6 group stage rounds advance to the knockout phase. That&apos;s a separate points-based game where everyone predicts the score of each knockout fixture — 5 points for the correct score, 2 points for the correct result. More details coming once the group stage is complete.
+                </p>
+              </section>
+
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        {/* ── Group Stage tab ────────────────────────────────────────────── */}
+        <TabsContent value="group-stage">
+          <WcPicksForm
+            wcPicks={wcPicks}
+            isLoadingWcPicks={isLoadingWcPicks}
+            wcFixtures={wcFixtures}
+            isLoadingWcFixtures={isLoadingWcFixtures}
+            refreshTrigger={refreshTrigger}
+            setRefreshTrigger={setRefreshTrigger}
+          />
+        </TabsContent>
+
+        {/* ── Knockout tab ───────────────────────────────────────────────── */}
+        <TabsContent value="knockout">
+          <Card className="rounded-xl bg-white shadow-sm">
+            <CardContent className="p-12 flex flex-col items-center gap-3 text-center">
+              <p className="text-4xl">🏆</p>
+              <p className="text-lg font-semibold text-gray-800">Knockout stage — coming soon</p>
+              <p className="text-sm text-muted-foreground max-w-sm">
+                Once the group stage is complete, surviving players will predict the scores of the knockout fixtures. Check back after 27 June.
+              </p>
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
 
       {/* ── FPL dashboard (commented out for the summer) ─────────────────── */}
-      {/* const [refreshTrigger, setRefreshTrigger] = useState(0);                */}
-      {/* ... restore by uncommenting the imports above and the block below ...   */}
-      {/*
-      <div className="grid gap-6 grid-cols-1 md:grid-cols-4 my-6">
-        <div className="w-full grid md:col-span-3">
-          <CurrentGame
-            currentGameResults={currentGameResults}
-            leagueName={leagueName}
-            isLoading={isLoadingLeagueName || isLoadingCurrentGameData}
-          />
-        </div>
-        <div className="w-full md:col-span-1">
-          <Predictions
-            session={session}
-            teamsArr={teamsArr}
-            results={results}
-            predictionWeekFixtures={predictionWeekFixtures}
-            setRefreshTrigger={setRefreshTrigger}
-            isLoading={isLoadingResults || isLoadingFplData}
-            currentGameId={currentGameId}
-          />
-        </div>
-      </div>
-      <div className="grid gap-6 grid-cols-1 md:grid-cols-4 my-6">
-        <div className="w-full md:col-span-2 relative">
-          <div className="flex flex-col gap-6 md:absolute md:inset-0">
-            <FixturesResults
-              fixtures={fixtures}
-              currentGwNumber={currentGwNumber}
-              teamsArr={teamsArr}
-              isLoading={isLoadingFixtures}
-            />
-            <div className="flex-1 min-h-0 flex flex-col">
-              <Injuries data={injuries} isLoading={isLoadingFplData} />
-            </div>
-          </div>
-        </div>
-        <div className="w-full md:col-span-2">
-          <LeagueTable
-            fixtures={fixtures}
-            isLoading={isLoadingFixtures}
-            teamsArr={teamsArr}
-          />
-        </div>
-      </div>
-      <div className="w-full overflow-x-auto my-6">
-        <PickPlanner
-          teams={teamsArr}
-          fixtures={fixtures || []}
-          currentGwNumber={currentGwNumber}
-          numWeeks={numWeeks}
-          setNumWeeks={setNumWeeks}
-          results={results || {}}
-          session={session}
-          currentGameId={currentGameId}
-        />
-      </div>
-      <Card className="rounded-xl bg-white p-2 my-6 shadow-sm overflow-auto md:hidden">
-        <CardHeader className="p-2 md:p-6">
-          <CardTitle>Results</CardTitle>
-          <CardDescription>View your previous results</CardDescription>
-        </CardHeader>
-        <CardContent className="p-2 md:p-6 md:pt-0">
-          {session === null ? (
-            <div style={{ display: 'flex', justifyContent: 'center' }}>
-              <a
-                style={{ color: 'blue', fontWeight: 600, textAlign: 'center' }}
-                href="/api/auth/signin"
-              >
-                Sign in to get started
-              </a>
-            </div>
-          ) : (
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Game</TableHead>
-                  {Array.from(Array(maxGameWeeks)).map((_, gameWeek) => (
-                    <TableHead key={`gw-headcell-${gameWeek + 1}`}>
-                      {`Round ${gameWeek + 1}`}
-                    </TableHead>
-                  ))}
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {Object.values(results).map((gameResults, gameIdx) => (
-                  <TableRow key={`game-row-${gameResults[0].game_id}`}>
-                    <TableCell className="font-medium">{gameIdx + 1}</TableCell>
-                    {gameResults.map((prediction, predictionIdx) => (
-                      <TableCell
-                        key={`gw-cell-${gameIdx}-${predictionIdx}`}
-                        className={`table-cell ${prediction.correct ? 'bg-green-200' : 'bg-red-200'}`}
-                      >
-                        <div style={{ display: 'flex', flexDirection: 'column', textAlign: 'center' }}>
-                          <div>
-                            <TeamName location="Home" prediction={prediction} /> v{' '}
-                            <TeamName location="Away" prediction={prediction} />
-                          </div>
-                          <div>
-                            <TeamScore location="Home" prediction={prediction} />{' '}
-                            <span className="font-thin">v</span>{' '}
-                            <TeamScore location="Away" prediction={prediction} />
-                          </div>
-                        </div>
-                      </TableCell>
-                    ))}
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          )}
-        </CardContent>
-      </Card>
-      */}
+      {/* ... restore by uncommenting the imports at the top ...              */}
     </main>
   );
 };

--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -126,7 +126,7 @@ const Page = () => {
                     <span className="font-bold text-gray-400 shrink-0 w-4">2</span>
                     <div>
                       <p className="font-semibold text-gray-900">Knockout Stage — Score Prediction</p>
-                      <p className="text-muted-foreground text-xs mt-0.5">Predict the score of a predefined knockout stage match. Earn 5 points for the correct score and 2 points for the correct outcome. Highest points total after The Final wins the pot!</p>
+                      <p className="text-muted-foreground text-xs mt-0.5">Predict the score of predefined knockout stage matches. Earn 5 points for the correct score and 2 points for the correct outcome. Highest points total after The Final wins the pot!</p>
                     </div>
                   </li>
                 </ol>

--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -1,149 +1,70 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
-import TileWrapper from '@/components/ui/tiles';
-import CurrentGame from './current-game-results';
-import FixturesResults from './fixtures-results';
-import Predictions from './predictions';
-import LeagueTable from './league-table';
-import PickPlanner from '@/components/PickPlanner';
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle
-} from '@/components/ui/card';
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-  TeamName,
-  TeamScore
-} from '@/components/ui/table';
-import { MIN_GW } from '@/lib/constants';
-import { FPLTeamName, Injury } from '@/lib/definitions';
-import { useSession } from 'next-auth/react';
-import useResults from 'app/hooks/useResults';
-import useFixtures from 'app/hooks/useFixtures';
-import useFplData, { FplData } from 'app/hooks/useFplData';
-import useLeagueInfo from 'app/hooks/useLeagueInfo';
-import useCurrentGameData from 'app/hooks/useCurrentGameData';
-import Injuries from './injuries';
+// ─── World Cup 2026 ───────────────────────────────────────────────────────────
+import WcPicksForm from './wc-picks-form';
 
-export type TeamsArr = {
-  id: number;
-  name: FPLTeamName;
-  short_name: string;
-}[];
+// ─── FPL Last Player Standing (commented out for WC summer) ──────────────────
+// import { useEffect, useMemo, useState } from 'react';
+// import TileWrapper from '@/components/ui/tiles';
+// import CurrentGame from './current-game-results';
+// import FixturesResults from './fixtures-results';
+// import Predictions from './predictions';
+// import LeagueTable from './league-table';
+// import PickPlanner from '@/components/PickPlanner';
+// import {
+//   Card,
+//   CardContent,
+//   CardDescription,
+//   CardHeader,
+//   CardTitle
+// } from '@/components/ui/card';
+// import {
+//   Table,
+//   TableBody,
+//   TableCell,
+//   TableHead,
+//   TableHeader,
+//   TableRow,
+//   TeamName,
+//   TeamScore
+// } from '@/components/ui/table';
+// import { MIN_GW } from '@/lib/constants';
+// import { FPLTeamName, Injury } from '@/lib/definitions';
+// import { useSession } from 'next-auth/react';
+// import useResults from 'app/hooks/useResults';
+// import useFixtures from 'app/hooks/useFixtures';
+// import useFplData, { FplData } from 'app/hooks/useFplData';
+// import useLeagueInfo from 'app/hooks/useLeagueInfo';
+// import useCurrentGameData from 'app/hooks/useCurrentGameData';
+// import Injuries from './injuries';
+
+// export type TeamsArr = {
+//   id: number;
+//   name: FPLTeamName;
+//   short_name: string;
+// }[];
 
 const Page = () => {
-  const [refreshTrigger, setRefreshTrigger] = useState(0);
-  const [numWeeks, setNumWeeks] = useState<number>(() => {
-    try {
-      const v =
-        typeof window !== 'undefined'
-          ? localStorage.getItem('pickPlanner:numWeeks')
-          : null;
-      return v ? Number(v) : 5;
-    } catch {
-      return 5;
-    }
-  });
-
-  // persist selection
-  useEffect(() => {
-    try {
-      localStorage.setItem('pickPlanner:numWeeks', String(numWeeks));
-    } catch {
-      // ignore
-    }
-  }, [numWeeks]);
-
-  const { data: session } = useSession();
-  const { results, isLoadingResults } = useResults({ refreshTrigger });
-
-  const { fixtures, isLoadingFixtures } = useFixtures();
-  const { fplData, isLoadingFplData } = useFplData();
-  const { leagueName, isLoadingLeagueName } = useLeagueInfo();
-  const { currentGameResults, currentGameId, isLoadingCurrentGameData } =
-    useCurrentGameData({ refreshTrigger });
-
-  const currentGwNumber =
-    !isLoadingFplData && fplData
-      ? fplData.events.find((obj) => obj.is_current === true)?.id || MIN_GW
-      : MIN_GW;
-
-  const predictionWeekFixtures = fixtures?.filter(
-    (fixture) => fixture.event === currentGwNumber + 1
-  );
-
-  const teamsArr: TeamsArr = useMemo(
-    () =>
-      !isLoadingFplData && fplData
-        ? fplData.teams.map(({ id, name, short_name }) => ({
-            id,
-            name,
-            short_name
-          }))
-        : [],
-    [isLoadingFplData, fplData]
-  );
-
-  const maxGameWeeks = isLoadingResults
-    ? 1
-    : Array.isArray(Object.values(results))
-      ? Object.values(results).reduce(
-          (maxLength, currentArray) => Math.max(maxLength, currentArray.length),
-          0
-        )
-      : 1;
-
-  const injuries: Injury[] =
-    fplData?.elements?.reduce<
-      {
-        web_name: string;
-        chance_of_playing_next_round: number | null;
-        news: string;
-        team_name: FPLTeamName | null;
-      }[]
-    >((acc, curr) => {
-      if (curr.status === 'i') {
-        acc.push({
-          web_name: curr.web_name,
-          chance_of_playing_next_round: curr.chance_of_playing_next_round,
-          news: curr.news,
-          team_name:
-            fplData?.teams.find((team) => team.id === curr.team)?.name || null
-        });
-      }
-      return acc;
-    }, []) ?? [];
-
   return (
     <main>
-      <div className="rounded-xl bg-gray-300 p-4 shadow-sm grid col-span-2 md:col-span-1 my-6">
-        <h1 className="text-4xl font-bold text-center mb-2 flex items-center justify-center gap-2">
-          Last Player Standing
+      {/* ── Hero ─────────────────────────────────────────────────────────── */}
+      <div className="rounded-xl bg-gray-300 p-4 shadow-sm my-6">
+        <h1 className="text-4xl font-bold text-center mb-2">
+          ⚽ World Cup 2026
         </h1>
-
-        <p className="rounded-xl px-4 py-4 text-center text-xl font-light italic">
-          <strong className="font-bold">Submit predictions</strong>,{' '}
-          <strong className="font-bold">plan picks</strong>,{' '}
-          <strong className="font-bold">view results</strong>, and{' '}
-          <strong className="font-bold">analyse performance</strong>.
+        <p className="text-center text-xl font-light italic px-4 py-2">
+          Last Player Standing — pick a team to win each round. Use the same
+          team twice and you&apos;re out.
         </p>
       </div>
 
-      {session === null || session === undefined ? null : (
-        <div className="my-6">
-          <TileWrapper refreshTrigger={refreshTrigger} />
-        </div>
-      )}
+      {/* ── Picks form ───────────────────────────────────────────────────── */}
+      <WcPicksForm />
 
+      {/* ── FPL dashboard (commented out for the summer) ─────────────────── */}
+      {/* const [refreshTrigger, setRefreshTrigger] = useState(0);                */}
+      {/* ... restore by uncommenting the imports above and the block below ...   */}
+      {/*
       <div className="grid gap-6 grid-cols-1 md:grid-cols-4 my-6">
         <div className="w-full grid md:col-span-3">
           <CurrentGame
@@ -152,7 +73,6 @@ const Page = () => {
             isLoading={isLoadingLeagueName || isLoadingCurrentGameData}
           />
         </div>
-
         <div className="w-full md:col-span-1">
           <Predictions
             session={session}
@@ -165,7 +85,6 @@ const Page = () => {
           />
         </div>
       </div>
-
       <div className="grid gap-6 grid-cols-1 md:grid-cols-4 my-6">
         <div className="w-full md:col-span-2 relative">
           <div className="flex flex-col gap-6 md:absolute md:inset-0">
@@ -175,13 +94,11 @@ const Page = () => {
               teamsArr={teamsArr}
               isLoading={isLoadingFixtures}
             />
-
             <div className="flex-1 min-h-0 flex flex-col">
               <Injuries data={injuries} isLoading={isLoadingFplData} />
             </div>
           </div>
         </div>
-
         <div className="w-full md:col-span-2">
           <LeagueTable
             fixtures={fixtures}
@@ -190,7 +107,6 @@ const Page = () => {
           />
         </div>
       </div>
-
       <div className="w-full overflow-x-auto my-6">
         <PickPlanner
           teams={teamsArr}
@@ -203,13 +119,11 @@ const Page = () => {
           currentGameId={currentGameId}
         />
       </div>
-
       <Card className="rounded-xl bg-white p-2 my-6 shadow-sm overflow-auto md:hidden">
         <CardHeader className="p-2 md:p-6">
           <CardTitle>Results</CardTitle>
           <CardDescription>View your previous results</CardDescription>
         </CardHeader>
-
         <CardContent className="p-2 md:p-6 md:pt-0">
           {session === null ? (
             <div style={{ display: 'flex', justifyContent: 'center' }}>
@@ -226,9 +140,9 @@ const Page = () => {
                 <TableRow>
                   <TableHead>Game</TableHead>
                   {Array.from(Array(maxGameWeeks)).map((_, gameWeek) => (
-                    <TableHead
-                      key={`gw-headcell-${gameWeek + 1}`}
-                    >{`Round ${gameWeek + 1}`}</TableHead>
+                    <TableHead key={`gw-headcell-${gameWeek + 1}`}>
+                      {`Round ${gameWeek + 1}`}
+                    </TableHead>
                   ))}
                 </TableRow>
               </TableHeader>
@@ -241,28 +155,15 @@ const Page = () => {
                         key={`gw-cell-${gameIdx}-${predictionIdx}`}
                         className={`table-cell ${prediction.correct ? 'bg-green-200' : 'bg-red-200'}`}
                       >
-                        <div
-                          style={{
-                            display: 'flex',
-                            flexDirection: 'column',
-                            textAlign: 'center'
-                          }}
-                        >
+                        <div style={{ display: 'flex', flexDirection: 'column', textAlign: 'center' }}>
                           <div>
-                            <TeamName location="Home" prediction={prediction} />{' '}
-                            v{' '}
+                            <TeamName location="Home" prediction={prediction} /> v{' '}
                             <TeamName location="Away" prediction={prediction} />
                           </div>
                           <div>
-                            <TeamScore
-                              location="Home"
-                              prediction={prediction}
-                            />{' '}
+                            <TeamScore location="Home" prediction={prediction} />{' '}
                             <span className="font-thin">v</span>{' '}
-                            <TeamScore
-                              location="Away"
-                              prediction={prediction}
-                            />
+                            <TeamScore location="Away" prediction={prediction} />
                           </div>
                         </div>
                       </TableCell>
@@ -274,6 +175,7 @@ const Page = () => {
           )}
         </CardContent>
       </Card>
+      */}
     </main>
   );
 };

--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -57,6 +57,7 @@ function formatDeadline(date: Date): string {
 }
 
 const Page = () => {
+  const [activeTab, setActiveTab] = useState('rules');
   const [refreshTrigger, setRefreshTrigger] = useState(0);
   const { wcFixtures, isLoadingWcFixtures } = useWcFixtures();
   const { wcPicks, isLoadingWcPicks } = useWcPicks({ refreshTrigger });
@@ -85,7 +86,7 @@ const Page = () => {
       </div>
 
       {/* ── Tabs ─────────────────────────────────────────────────────────── */}
-      <Tabs defaultValue="rules" className="w-full">
+      <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
         <TabsList className="w-full mb-4">
           <TabsTrigger value="rules" className="flex-1">
             Rules
@@ -139,6 +140,12 @@ const Page = () => {
               <div className="border-l-4 border-amber-400 px-6 py-4 bg-amber-50">
                 <p className="text-xs font-bold tracking-widest text-amber-600 uppercase mb-0.5">Phase 1 · Rounds 1–6</p>
                 <h3 className="text-lg font-bold text-gray-900">The Group Stage</h3>
+                <button
+                  onClick={() => setActiveTab('group-stage')}
+                  className="mt-2 text-xs font-semibold text-amber-700 underline underline-offset-2 hover:text-amber-900 transition-colors"
+                >
+                  Submit your predictions →
+                </button>
               </div>
               <CardContent className="p-6 flex flex-col gap-4">
                 <p>

--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -108,7 +108,7 @@ const Page = () => {
             {/* Badges + intro */}
             <Card className="rounded-xl bg-white shadow-sm">
               <CardContent className="p-6 flex flex-col gap-4">
-                <div className="flex flex-wrap gap-2">
+                <div className="flex flex-wrap gap-2 justify-center">
                   <span className="px-3 py-1 rounded-full bg-amber-400 text-white text-xs font-semibold">£10 entry</span>
                   <span className="px-3 py-1 rounded-full bg-gray-800 text-white text-xs font-semibold">Winner takes all</span>
                   <span className="px-3 py-1 rounded-full bg-gray-800 text-white text-xs font-semibold">11 rounds</span>

--- a/app/(dashboard)/predictions.tsx
+++ b/app/(dashboard)/predictions.tsx
@@ -9,7 +9,7 @@ import {
   CardTitle
 } from '@/components/ui/card';
 import { Select } from '@/components/ui/select';
-import { TeamsArr } from './page';
+import { TeamsArr } from '@/lib/definitions';
 import { FixturesData, Results } from '@/lib/definitions';
 import { Button } from '@/components/ui/button';
 import { Session } from 'next-auth';

--- a/app/(dashboard)/privacy/page.tsx
+++ b/app/(dashboard)/privacy/page.tsx
@@ -1,0 +1,126 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+export default function PrivacyPage() {
+  return (
+    <main className="max-w-2xl mx-auto py-8 px-4">
+      <Card className="rounded-xl bg-white shadow-sm">
+        <CardHeader className="p-6 pb-2">
+          <CardTitle className="text-2xl">Privacy Policy</CardTitle>
+          <p className="text-xs text-muted-foreground mt-1">Last updated: May 2026</p>
+        </CardHeader>
+        <CardContent className="p-6 pt-4 flex flex-col gap-6 text-sm text-gray-700 leading-relaxed">
+
+          <p>
+            This site runs a prediction league game. This policy explains what data I collect,
+            why, and what your rights are.
+          </p>
+
+          <section>
+            <h2 className="font-semibold text-base text-gray-900 mb-2">Who I am</h2>
+            <p>
+              This site is operated by Alex Peirson. If you have any questions about your data,
+              you can contact me at{' '}
+              <a href="mailto:alexlmsapp@icloud.com" className="underline hover:text-gray-900">
+                alexlmsapp@icloud.com
+              </a>.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-semibold text-base text-gray-900 mb-2">What I collect</h2>
+            <p className="mb-2">
+              When you log in and use the site, I store the following:
+            </p>
+            <ul className="list-disc list-inside pl-2 flex flex-col gap-1 text-gray-600">
+              <li>Your email address</li>
+              <li>Your name</li>
+              <li>Your league membership (which league you belong to)</li>
+              <li>Your predictions</li>
+              <li>Your results</li>
+            </ul>
+            <p className="mt-2 text-muted-foreground">
+              I don&apos;t collect anything beyond what&apos;s listed above.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-semibold text-base text-gray-900 mb-2">How you log in</h2>
+            <p>
+              I use a third-party OAuth provider to handle login. I don&apos;t store your
+              password — authentication is handled entirely by the provider you sign in with.
+              I only receive your email address from them.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-semibold text-base text-gray-900 mb-2">Where your data is stored</h2>
+            <p>
+              Your data is stored in a PostgreSQL database hosted by{' '}
+              <a href="https://neon.tech" target="_blank" rel="noopener noreferrer" className="underline hover:text-gray-900">
+                Neon
+              </a>{' '}
+              (neon.tech), and the site itself is hosted on{' '}
+              <a href="https://vercel.com" target="_blank" rel="noopener noreferrer" className="underline hover:text-gray-900">
+                Vercel
+              </a>{' '}
+              (vercel.com). Both are reputable providers with their own security and data
+              protection measures.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-semibold text-base text-gray-900 mb-2">Why I collect it</h2>
+            <p>
+              I use your data to make the game work — to identify you, record your predictions,
+              calculate results, and show league standings. I don&apos;t use your data for
+              marketing or advertising and I don&apos;t share it with anyone else.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-semibold text-base text-gray-900 mb-2">How long I keep it</h2>
+            <p>
+              I keep your data for as long as the league is running. If you&apos;d like your
+              data removed at any time, just get in touch and I&apos;ll delete it.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-semibold text-base text-gray-900 mb-2">Your rights</h2>
+            <p className="mb-2">
+              Under UK data protection law, you have the right to:
+            </p>
+            <ul className="list-disc list-inside pl-2 flex flex-col gap-1 text-gray-600">
+              <li>Ask what data I hold about you</li>
+              <li>Ask me to correct anything that&apos;s wrong</li>
+              <li>Ask me to delete your data</li>
+              <li>Withdraw from the league and have your data removed</li>
+            </ul>
+            <p className="mt-2 text-muted-foreground">
+              To exercise any of these, just contact me using the details above.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-semibold text-base text-gray-900 mb-2">Cookies</h2>
+            <p>
+              I use a session cookie to keep you logged in. I don&apos;t use tracking cookies,
+              advertising cookies, or any third-party analytics.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-semibold text-base text-gray-900 mb-2">Contact</h2>
+            <p>
+              If you have any questions or want your data removed, email me at{' '}
+              <a href="mailto:alexlmsapp@icloud.com" className="underline hover:text-gray-900">
+                alexlmsapp@icloud.com
+              </a>.
+            </p>
+          </section>
+
+        </CardContent>
+      </Card>
+    </main>
+  );
+}

--- a/app/(dashboard)/wc-picks-form.tsx
+++ b/app/(dashboard)/wc-picks-form.tsx
@@ -167,10 +167,17 @@ export default function WcPicksForm({
       return !isLocked && !drafts[r] && wcPicks.some((p) => p.round_number === r);
     });
 
-    if (hasUnsavedDrafts || hasClearedPick) {
+    if (hasUnsavedDrafts) {
       return {
         message: 'You have unsaved changes — save your picks before the deadline!',
         className: 'bg-red-50 border-red-200 text-red-700'
+      } as const;
+    }
+
+    if (hasClearedPick) {
+      return {
+        message: 'You\'ve removed a selection — pick a replacement team before saving.',
+        className: 'bg-amber-50 border-amber-200 text-amber-800'
       } as const;
     }
 

--- a/app/(dashboard)/wc-picks-form.tsx
+++ b/app/(dashboard)/wc-picks-form.tsx
@@ -267,16 +267,16 @@ export default function WcPicksForm({
     );
   }
 
+  // ── Guest view ─────────────────────────────────────────────────────────────
   if (!session) {
     return (
-      <div className="text-center py-12">
-        <a
-          href="/api/auth/signin"
-          className="text-blue-600 font-semibold underline"
-        >
-          Sign in to submit your picks
-        </a>
-      </div>
+      <GuestView
+        activeRound={activeRound}
+        setActiveRound={setActiveRound}
+        fixturesByRound={fixturesByRound}
+        usedTeamIds={usedTeamIds}
+        isLoadingWcFixtures={isLoadingWcFixtures}
+      />
     );
   }
 
@@ -379,6 +379,160 @@ export default function WcPicksForm({
           )}
         </Button>
       )}
+    </div>
+  );
+}
+
+// ── GuestView ────────────────────────────────────────────────────────────────
+
+function GuestView({
+  activeRound,
+  setActiveRound,
+  fixturesByRound,
+  usedTeamIds,
+  isLoadingWcFixtures
+}: {
+  activeRound: number;
+  setActiveRound: (r: number) => void;
+  fixturesByRound: Record<number, WcFixture[]>;
+  usedTeamIds: Set<number>;
+  isLoadingWcFixtures: boolean;
+}) {
+  const registrationOpen = new Date() < WC_ROUND_DEADLINES[1];
+  const [email, setEmail] = useState('');
+  const [status, setStatus] = useState<'idle' | 'submitting' | 'success' | 'error'>('idle');
+  const [errorMsg, setErrorMsg] = useState('');
+
+  const handleRegister = async () => {
+    setStatus('submitting');
+    setErrorMsg('');
+    try {
+      const res = await fetch('/api/wc/register-interest', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email })
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || 'Something went wrong.');
+      }
+      setStatus('success');
+    } catch (err: unknown) {
+      setErrorMsg(err instanceof Error ? err.message : 'Something went wrong.');
+      setStatus('error');
+    }
+  };
+
+  if (isLoadingWcFixtures) {
+    return (
+      <div className="flex justify-center items-center py-16">
+        <Loader className="animate-spin h-6 w-6 text-gray-400" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Locked round navigation — browse only */}
+      <div className="flex flex-col gap-2 opacity-50 pointer-events-none select-none">
+        <p className="text-xs text-muted-foreground text-center">
+          Round {activeRound} of 6
+        </p>
+        <div className="flex items-center justify-between gap-3">
+          <button className="p-2 rounded-lg border border-gray-200 text-gray-400" disabled>
+            <ChevronLeft className="h-4 w-4" />
+          </button>
+          <div className="flex gap-2.5">
+            {[1, 2, 3, 4, 5, 6].map((r) => (
+              <span key={r} className={cn('h-3 w-3 rounded-full bg-gray-300', r === activeRound && 'ring-2 ring-offset-2 ring-gray-300 scale-110')} />
+            ))}
+          </div>
+          <button className="p-2 rounded-lg border border-gray-200 text-gray-400" disabled>
+            <ChevronRight className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+
+      {/* Locked round card */}
+      <div className="relative">
+        <div className="opacity-40 pointer-events-none select-none">
+          <WcRoundCard
+            roundNumber={activeRound}
+            fixtures={fixturesByRound[activeRound] ?? []}
+            currentDraft={null}
+            existingPick={null}
+            usedTeamIds={usedTeamIds}
+            onPickTeam={() => {}}
+            isEliminated={true}
+          />
+        </div>
+        <div className="absolute inset-0 flex items-center justify-center rounded-xl">
+          <span className="bg-white/90 text-gray-600 text-sm font-medium px-4 py-2 rounded-full shadow-sm border border-gray-200">
+            🔒 Sign in to make picks
+          </span>
+        </div>
+      </div>
+
+      {/* Register interest / sign in */}
+      <div className="rounded-xl border border-gray-200 bg-white shadow-sm p-6 flex flex-col gap-4">
+        {registrationOpen ? (
+          <>
+            <div>
+              <p className="font-semibold text-gray-900">Want to play?</p>
+              <p className="text-sm text-muted-foreground mt-0.5">
+                Register your interest and you&apos;ll be added to the game before the deadline.
+              </p>
+            </div>
+
+            {status === 'success' ? (
+              <div className="rounded-lg bg-green-50 border border-green-200 px-4 py-3 text-green-700 text-sm font-medium">
+                Request sent! You&apos;ll hear back before the deadline.
+              </div>
+            ) : (
+              <div className="flex gap-2">
+                <input
+                  type="email"
+                  placeholder="your@email.com"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  className="flex-1 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+                <Button
+                  onClick={handleRegister}
+                  disabled={status === 'submitting' || !email.includes('@')}
+                  size="sm"
+                >
+                  {status === 'submitting' ? (
+                    <Loader className="animate-spin h-4 w-4" />
+                  ) : (
+                    'Register interest'
+                  )}
+                </Button>
+              </div>
+            )}
+
+            {status === 'error' && (
+              <p className="text-red-600 text-xs">{errorMsg}</p>
+            )}
+
+            <p className="text-xs text-muted-foreground">
+              Already have an account?{' '}
+              <a href="/api/auth/signin" className="text-blue-600 underline">Sign in</a>
+            </p>
+          </>
+        ) : (
+          <>
+            <p className="font-semibold text-gray-900">Registration is closed</p>
+            <p className="text-sm text-muted-foreground">
+              The game has already started and new registrations are no longer being accepted.
+            </p>
+            <p className="text-xs text-muted-foreground">
+              Already have an account?{' '}
+              <a href="/api/auth/signin" className="text-blue-600 underline">Sign in</a>
+            </p>
+          </>
+        )}
+      </div>
     </div>
   );
 }

--- a/app/(dashboard)/wc-picks-form.tsx
+++ b/app/(dashboard)/wc-picks-form.tsx
@@ -48,7 +48,7 @@ export default function WcPicksForm() {
 
   // Initialise drafts from server picks once loaded, then overlay localStorage
   useEffect(() => {
-    if (isLoadingWcPicks || draftsInitialised) return;
+    if (isLoadingWcPicks || draftsInitialised || !session) return;
 
     const base = initDrafts(wcPicks);
 
@@ -181,16 +181,11 @@ export default function WcPicksForm() {
       }
 
       setSuccess(true);
+      // Refresh server state (badges, is_correct) but keep drafts as-is — they
+      // already match what was just saved, so hasUnsavedDrafts resolves to false
+      // once the refetched picks land. Re-initialising here would race the
+      // refetch and re-seed stale drafts.
       setRefreshTrigger((t) => t + 1);
-      setDraftsInitialised(false); // re-init from server on next load
-
-      if (session?.user?.id) {
-        try {
-          localStorage.removeItem(`wc:draft:${session.user.id}`);
-        } catch {
-          // ignore
-        }
-      }
     } catch (err: unknown) {
       setError(
         err instanceof Error ? err.message : 'Something went wrong. Please try again.'

--- a/app/(dashboard)/wc-picks-form.tsx
+++ b/app/(dashboard)/wc-picks-form.tsx
@@ -2,7 +2,8 @@
 
 import { useState, useEffect, useMemo, useCallback, Dispatch, SetStateAction } from 'react';
 import { useSession } from 'next-auth/react';
-import { Loader } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Loader } from 'lucide-react';
+import { cn } from '@/lib/utils';
 import WcRoundCard from './wc-round-card';
 import { Button } from '@/components/ui/button';
 import { WcFixture, WcPick, PickDraft } from '@/lib/wc-definitions';
@@ -54,6 +55,7 @@ export default function WcPicksForm({
     6: null
   });
   const [draftsInitialised, setDraftsInitialised] = useState(false);
+  const [activeRound, setActiveRound] = useState(1);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -85,6 +87,16 @@ export default function WcPicksForm({
 
     setDrafts(base);
     setDraftsInitialised(true);
+
+    // Jump to first open round without a saved pick
+    const now = new Date();
+    const firstMissing =
+      [1, 2, 3, 4, 5, 6].find(
+        (r) =>
+          now < WC_ROUND_DEADLINES[r] &&
+          !wcPicks.some((p) => p.round_number === r)
+      ) ?? 1;
+    setActiveRound(firstMissing);
   }, [isLoadingWcPicks, wcPicks, session, draftsInitialised]);
 
   // Persist drafts to localStorage whenever they change
@@ -182,17 +194,26 @@ export default function WcPicksForm({
 
   const handlePickTeam = useCallback(
     (round: number, fixtureId: number, teamId: number) => {
+      const isDeselect = drafts[round]?.picked_team_id === teamId;
+
       setDrafts((prev) => {
         const current = prev[round];
-        // Clicking the already-selected team deselects it
         if (current?.picked_team_id === teamId) {
           return { ...prev, [round]: null };
         }
         return { ...prev, [round]: { fixture_id: fixtureId, picked_team_id: teamId } };
       });
+
+      // Auto-advance to next round after picking (not on deselect)
+      if (!isDeselect) {
+        setTimeout(() => {
+          setActiveRound((r) => Math.min(r + 1, 6));
+        }, 300);
+      }
+
       setError(null);
     },
-    []
+    [drafts]
   );
 
   const handleSubmit = async () => {
@@ -279,20 +300,67 @@ export default function WcPicksForm({
         </div>
       )}
 
-      {[1, 2, 3, 4, 5, 6].map((round) => (
-        <WcRoundCard
-          key={round}
-          roundNumber={round}
-          fixtures={fixturesByRound[round] ?? []}
-          currentDraft={drafts[round] ?? null}
-          existingPick={wcPicks.find((p) => p.round_number === round) ?? null}
-          usedTeamIds={usedTeamIds}
-          onPickTeam={(fixtureId, teamId) =>
-            handlePickTeam(round, fixtureId, teamId)
-          }
-          isEliminated={isEliminated}
-        />
-      ))}
+      {/* Round navigation */}
+      <div className="flex flex-col gap-2">
+        <p className="text-xs text-muted-foreground text-center">
+          Round {activeRound} of 6
+        </p>
+        <div className="flex items-center justify-between gap-3">
+          <button
+            onClick={() => setActiveRound((r) => Math.max(r - 1, 1))}
+            disabled={activeRound === 1}
+            className="p-2 rounded-lg border border-gray-200 text-gray-500 hover:bg-gray-50 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </button>
+
+          <div className="flex gap-2.5">
+            {[1, 2, 3, 4, 5, 6].map((r) => {
+              const existing = wcPicks.find((p) => p.round_number === r);
+              const draft = drafts[r];
+              const dotColor =
+                existing?.is_correct === false ? 'bg-red-500' :
+                existing?.is_correct === true  ? 'bg-green-500' :
+                existing && draft && draft.picked_team_id === existing.picked_team_id ? 'bg-green-400' :
+                draft || (!draft && existing) ? 'bg-amber-400' :
+                'bg-gray-300';
+              return (
+                <button
+                  key={r}
+                  onClick={() => setActiveRound(r)}
+                  aria-label={`Go to round ${r}`}
+                  className={cn(
+                    'h-3 w-3 rounded-full transition-all',
+                    dotColor,
+                    r === activeRound && 'ring-2 ring-offset-2 ring-gray-400 scale-110'
+                  )}
+                />
+              );
+            })}
+          </div>
+
+          <button
+            onClick={() => setActiveRound((r) => Math.min(r + 1, 6))}
+            disabled={activeRound === 6}
+            className="p-2 rounded-lg border border-gray-200 text-gray-500 hover:bg-gray-50 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+          >
+            <ChevronRight className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+
+      {/* Active round card */}
+      <WcRoundCard
+        roundNumber={activeRound}
+        fixtures={fixturesByRound[activeRound] ?? []}
+        currentDraft={drafts[activeRound] ?? null}
+        existingPick={wcPicks.find((p) => p.round_number === activeRound) ?? null}
+        usedTeamIds={usedTeamIds}
+        onPickTeam={(fixtureId, teamId) =>
+          handlePickTeam(activeRound, fixtureId, teamId)
+        }
+        isEliminated={isEliminated}
+      />
 
       {!isEliminated && (
         <Button

--- a/app/(dashboard)/wc-picks-form.tsx
+++ b/app/(dashboard)/wc-picks-form.tsx
@@ -8,6 +8,7 @@ import useWcPicks from 'app/hooks/useWcPicks';
 import WcRoundCard from './wc-round-card';
 import { Button } from '@/components/ui/button';
 import { WcFixture, WcPick, PickDraft } from '@/lib/wc-definitions';
+import { WC_ROUND_DEADLINES } from '@/lib/wc-constants';
 
 function initDrafts(picks: WcPick[]): Record<number, PickDraft | null> {
   const drafts: Record<number, PickDraft | null> = {
@@ -133,6 +134,42 @@ export default function WcPicksForm() {
     [drafts, wcPicks]
   );
 
+  const statusBanner = useMemo(() => {
+    if (isEliminated) return null; // has its own banner
+
+    const now = new Date();
+
+    // A round where the user had a saved pick but has since cleared the draft
+    const hasClearedPick = [1, 2, 3, 4, 5, 6].some((r) => {
+      const isLocked = now > WC_ROUND_DEADLINES[r];
+      return !isLocked && !drafts[r] && wcPicks.some((p) => p.round_number === r);
+    });
+
+    if (hasUnsavedDrafts || hasClearedPick) {
+      return {
+        message: 'You have unsaved changes — save your picks before the deadline!',
+        className: 'bg-red-50 border-red-200 text-red-700'
+      } as const;
+    }
+
+    const missingCount = [1, 2, 3, 4, 5, 6].filter((r) => {
+      const isLocked = now > WC_ROUND_DEADLINES[r];
+      return !isLocked && !drafts[r] && !wcPicks.some((p) => p.round_number === r);
+    }).length;
+
+    if (missingCount > 0) {
+      return {
+        message: `You still have ${missingCount} round${missingCount > 1 ? 's' : ''} without a prediction — pick a team for every round and save before the deadline.`,
+        className: 'bg-amber-50 border-amber-200 text-amber-800'
+      } as const;
+    }
+
+    return {
+      message: 'All predictions saved — good luck! 🎉',
+      className: 'bg-green-50 border-green-200 text-green-700'
+    } as const;
+  }, [isEliminated, hasUnsavedDrafts, drafts, wcPicks]);
+
   const handlePickTeam = useCallback(
     (round: number, fixtureId: number, teamId: number) => {
       setDrafts((prev) => {
@@ -224,15 +261,9 @@ export default function WcPicksForm() {
         </div>
       )}
 
-      {hasUnsavedDrafts && !isEliminated && (
-        <div className="rounded-xl bg-amber-50 border border-amber-200 px-4 py-3 text-amber-800 text-sm font-medium">
-          You have unsaved picks — submit before the deadline!
-        </div>
-      )}
-
-      {success && (
-        <div className="rounded-xl bg-green-50 border border-green-200 px-4 py-3 text-green-700 text-sm font-medium">
-          Picks saved! A confirmation email is on its way.
+      {statusBanner && (
+        <div className={`rounded-xl border px-4 py-3 text-sm font-medium ${statusBanner.className}`}>
+          {statusBanner.message}
         </div>
       )}
 

--- a/app/(dashboard)/wc-picks-form.tsx
+++ b/app/(dashboard)/wc-picks-form.tsx
@@ -137,16 +137,23 @@ export default function WcPicksForm({
     return map;
   }, [wcFixtures]);
 
-  // Set of all team IDs currently selected across all rounds
-  const usedTeamIds = useMemo(
-    () =>
-      new Set(
-        Object.values(drafts)
-          .filter((d): d is PickDraft => d !== null)
-          .map((d) => d.picked_team_id)
-      ),
-    [drafts]
-  );
+  // Set of all team IDs considered "used" across all rounds.
+  // If a draft exists for a round, use it. If the draft has been cleared but
+  // a saved pick exists for that round, treat the saved team as still used —
+  // otherwise the UI would allow re-selecting it in another round.
+  const usedTeamIds = useMemo(() => {
+    const ids = new Set<number>();
+    for (let r = 1; r <= 6; r++) {
+      const draft = drafts[r];
+      if (draft) {
+        ids.add(draft.picked_team_id);
+      } else {
+        const existing = wcPicks.find((p) => p.round_number === r);
+        if (existing) ids.add(existing.picked_team_id);
+      }
+    }
+    return ids;
+  }, [drafts, wcPicks]);
 
   const isEliminated = wcPicks.some((p) => p.is_correct === false);
 
@@ -220,13 +227,6 @@ export default function WcPicksForm({
         }
         return { ...prev, [round]: { fixture_id: fixtureId, picked_team_id: teamId } };
       });
-
-      // Auto-advance to next round after picking (not on deselect)
-      if (!isDeselect) {
-        setTimeout(() => {
-          setActiveRound((r) => Math.min(r + 1, 6));
-        }, 300);
-      }
 
       setError(null);
     },
@@ -334,15 +334,17 @@ export default function WcPicksForm({
               'Save picks'
             )}
           </Button>
-          <p className="text-xs text-muted-foreground text-center">
-            Issues submitting?{' '}
-            <a
-              href={`mailto:${process.env.NEXT_PUBLIC_MY_EMAIL_ADDRESS}?subject=World%20Cup%202026%20-%20Prediction%20Submission&body=Hi%2C%20please%20find%20my%20predictions%20below%3A%0A%0A`}
-              className="underline hover:text-foreground transition-colors"
-            >
-              Email your predictions instead
-            </a>
-          </p>
+          {process.env.NEXT_PUBLIC_MY_EMAIL_ADDRESS && (
+            <p className="text-xs text-muted-foreground text-center">
+              Issues submitting?{' '}
+              <a
+                href={`mailto:${process.env.NEXT_PUBLIC_MY_EMAIL_ADDRESS}?subject=World%20Cup%202026%20-%20Prediction%20Submission&body=Hi%2C%20please%20find%20my%20predictions%20below%3A%0A%0A`}
+                className="underline hover:text-foreground transition-colors"
+              >
+                Email your predictions instead
+              </a>
+            </p>
+          )}
         </div>
       )}
 
@@ -558,6 +560,8 @@ function GuestView({
             <p className="text-xs text-muted-foreground">
               Already have an account?{' '}
               <a href="/api/auth/signin" className="text-blue-600 underline">Sign in</a>
+              {' · '}
+              <a href="/privacy" target="_blank" rel="noopener noreferrer" className="underline">Privacy policy</a>
             </p>
           </>
         ) : (
@@ -569,6 +573,8 @@ function GuestView({
             <p className="text-xs text-muted-foreground">
               Already have an account?{' '}
               <a href="/api/auth/signin" className="text-blue-600 underline">Sign in</a>
+              {' · '}
+              <a href="/privacy" target="_blank" rel="noopener noreferrer" className="underline">Privacy policy</a>
             </p>
           </>
         )}

--- a/app/(dashboard)/wc-picks-form.tsx
+++ b/app/(dashboard)/wc-picks-form.tsx
@@ -1,14 +1,21 @@
 'use client';
 
-import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useState, useEffect, useMemo, useCallback, Dispatch, SetStateAction } from 'react';
 import { useSession } from 'next-auth/react';
 import { Loader } from 'lucide-react';
-import useWcFixtures from 'app/hooks/useWcFixtures';
-import useWcPicks from 'app/hooks/useWcPicks';
 import WcRoundCard from './wc-round-card';
 import { Button } from '@/components/ui/button';
 import { WcFixture, WcPick, PickDraft } from '@/lib/wc-definitions';
 import { WC_ROUND_DEADLINES } from '@/lib/wc-constants';
+
+interface WcPicksFormProps {
+  wcPicks: WcPick[];
+  isLoadingWcPicks: boolean;
+  wcFixtures: WcFixture[];
+  isLoadingWcFixtures: boolean;
+  refreshTrigger: number;
+  setRefreshTrigger: Dispatch<SetStateAction<number>>;
+}
 
 function initDrafts(picks: WcPick[]): Record<number, PickDraft | null> {
   const drafts: Record<number, PickDraft | null> = {
@@ -28,11 +35,15 @@ function initDrafts(picks: WcPick[]): Record<number, PickDraft | null> {
   return drafts;
 }
 
-export default function WcPicksForm() {
+export default function WcPicksForm({
+  wcPicks,
+  isLoadingWcPicks,
+  wcFixtures,
+  isLoadingWcFixtures,
+  refreshTrigger,
+  setRefreshTrigger
+}: WcPicksFormProps) {
   const { data: session } = useSession();
-  const [refreshTrigger, setRefreshTrigger] = useState(0);
-  const { wcFixtures, isLoadingWcFixtures } = useWcFixtures();
-  const { wcPicks, isLoadingWcPicks } = useWcPicks({ refreshTrigger });
 
   const [drafts, setDrafts] = useState<Record<number, PickDraft | null>>({
     1: null,
@@ -45,7 +56,6 @@ export default function WcPicksForm() {
   const [draftsInitialised, setDraftsInitialised] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [success, setSuccess] = useState(false);
 
   // Initialise drafts from server picks once loaded, then overlay localStorage
   useEffect(() => {
@@ -181,7 +191,6 @@ export default function WcPicksForm() {
         return { ...prev, [round]: { fixture_id: fixtureId, picked_team_id: teamId } };
       });
       setError(null);
-      setSuccess(false);
     },
     []
   );
@@ -189,7 +198,6 @@ export default function WcPicksForm() {
   const handleSubmit = async () => {
     setIsSubmitting(true);
     setError(null);
-    setSuccess(false);
 
     const picks = Object.entries(drafts)
       .filter(([, draft]) => draft !== null)
@@ -217,11 +225,9 @@ export default function WcPicksForm() {
         throw new Error(data.error || 'Failed to save picks');
       }
 
-      setSuccess(true);
       // Refresh server state (badges, is_correct) but keep drafts as-is — they
       // already match what was just saved, so hasUnsavedDrafts resolves to false
-      // once the refetched picks land. Re-initialising here would race the
-      // refetch and re-seed stale drafts.
+      // once the refetched picks land.
       setRefreshTrigger((t) => t + 1);
     } catch (err: unknown) {
       setError(

--- a/app/(dashboard)/wc-picks-form.tsx
+++ b/app/(dashboard)/wc-picks-form.tsx
@@ -1,0 +1,284 @@
+'use client';
+
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useSession } from 'next-auth/react';
+import { Loader } from 'lucide-react';
+import useWcFixtures from 'app/hooks/useWcFixtures';
+import useWcPicks from 'app/hooks/useWcPicks';
+import WcRoundCard from './wc-round-card';
+import { Button } from '@/components/ui/button';
+import { WcFixture, WcPick, PickDraft } from '@/lib/wc-definitions';
+
+function initDrafts(picks: WcPick[]): Record<number, PickDraft | null> {
+  const drafts: Record<number, PickDraft | null> = {
+    1: null,
+    2: null,
+    3: null,
+    4: null,
+    5: null,
+    6: null
+  };
+  for (const pick of picks) {
+    drafts[pick.round_number] = {
+      fixture_id: pick.fixture_id,
+      picked_team_id: pick.picked_team_id
+    };
+  }
+  return drafts;
+}
+
+export default function WcPicksForm() {
+  const { data: session } = useSession();
+  const [refreshTrigger, setRefreshTrigger] = useState(0);
+  const { wcFixtures, isLoadingWcFixtures } = useWcFixtures();
+  const { wcPicks, isLoadingWcPicks } = useWcPicks({ refreshTrigger });
+
+  const [drafts, setDrafts] = useState<Record<number, PickDraft | null>>({
+    1: null,
+    2: null,
+    3: null,
+    4: null,
+    5: null,
+    6: null
+  });
+  const [draftsInitialised, setDraftsInitialised] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  // Initialise drafts from server picks once loaded, then overlay localStorage
+  useEffect(() => {
+    if (isLoadingWcPicks || draftsInitialised) return;
+
+    const base = initDrafts(wcPicks);
+
+    if (session?.user?.id) {
+      try {
+        const stored = localStorage.getItem(`wc:draft:${session.user.id}`);
+        if (stored) {
+          const local = JSON.parse(stored) as Record<number, PickDraft | null>;
+          for (const [roundStr, localDraft] of Object.entries(local)) {
+            const round = Number(roundStr);
+            const existing = wcPicks.find((p) => p.round_number === round);
+            const isSettled =
+              existing != null && existing.is_correct != null;
+            if (!isSettled && localDraft) {
+              base[round] = localDraft;
+            }
+          }
+        }
+      } catch {
+        // ignore localStorage errors
+      }
+    }
+
+    setDrafts(base);
+    setDraftsInitialised(true);
+  }, [isLoadingWcPicks, wcPicks, session, draftsInitialised]);
+
+  // Persist drafts to localStorage whenever they change
+  useEffect(() => {
+    if (!draftsInitialised || !session?.user?.id) return;
+    try {
+      localStorage.setItem(
+        `wc:draft:${session.user.id}`,
+        JSON.stringify(drafts)
+      );
+    } catch {
+      // ignore
+    }
+  }, [drafts, draftsInitialised, session?.user?.id]);
+
+  const fixturesByRound = useMemo(() => {
+    const map: Record<number, WcFixture[]> = {
+      1: [],
+      2: [],
+      3: [],
+      4: [],
+      5: [],
+      6: []
+    };
+    for (const f of wcFixtures) {
+      if (map[f.round_number]) map[f.round_number].push(f);
+    }
+    return map;
+  }, [wcFixtures]);
+
+  // Set of all team IDs currently selected across all rounds
+  const usedTeamIds = useMemo(
+    () =>
+      new Set(
+        Object.values(drafts)
+          .filter((d): d is PickDraft => d !== null)
+          .map((d) => d.picked_team_id)
+      ),
+    [drafts]
+  );
+
+  const isEliminated = wcPicks.some((p) => p.is_correct === false);
+
+  const hasUnsavedDrafts = useMemo(
+    () =>
+      Object.entries(drafts).some(([roundStr, draft]) => {
+        if (!draft) return false;
+        const existing = wcPicks.find(
+          (p) => p.round_number === Number(roundStr)
+        );
+        if (!existing) return true;
+        return (
+          existing.picked_team_id !== draft.picked_team_id ||
+          existing.fixture_id !== draft.fixture_id
+        );
+      }),
+    [drafts, wcPicks]
+  );
+
+  const handlePickTeam = useCallback(
+    (round: number, fixtureId: number, teamId: number) => {
+      setDrafts((prev) => {
+        const current = prev[round];
+        // Clicking the already-selected team deselects it
+        if (current?.picked_team_id === teamId) {
+          return { ...prev, [round]: null };
+        }
+        return { ...prev, [round]: { fixture_id: fixtureId, picked_team_id: teamId } };
+      });
+      setError(null);
+      setSuccess(false);
+    },
+    []
+  );
+
+  const handleSubmit = async () => {
+    setIsSubmitting(true);
+    setError(null);
+    setSuccess(false);
+
+    const picks = Object.entries(drafts)
+      .filter(([, draft]) => draft !== null)
+      .map(([roundStr, draft]) => ({
+        round_number: Number(roundStr),
+        fixture_id: draft!.fixture_id,
+        picked_team_id: draft!.picked_team_id
+      }));
+
+    if (picks.length === 0) {
+      setError('No picks selected.');
+      setIsSubmitting(false);
+      return;
+    }
+
+    try {
+      const res = await fetch('/api/wc/picks', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ picks })
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || 'Failed to save picks');
+      }
+
+      setSuccess(true);
+      setRefreshTrigger((t) => t + 1);
+      setDraftsInitialised(false); // re-init from server on next load
+
+      if (session?.user?.id) {
+        try {
+          localStorage.removeItem(`wc:draft:${session.user.id}`);
+        } catch {
+          // ignore
+        }
+      }
+    } catch (err: unknown) {
+      setError(
+        err instanceof Error ? err.message : 'Something went wrong. Please try again.'
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (isLoadingWcFixtures || isLoadingWcPicks) {
+    return (
+      <div className="flex justify-center items-center py-16">
+        <Loader className="animate-spin h-6 w-6 text-gray-400" />
+      </div>
+    );
+  }
+
+  if (!session) {
+    return (
+      <div className="text-center py-12">
+        <a
+          href="/api/auth/signin"
+          className="text-blue-600 font-semibold underline"
+        >
+          Sign in to submit your picks
+        </a>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      {isEliminated && (
+        <div className="rounded-xl bg-red-50 border border-red-200 px-4 py-3 text-red-700 text-sm font-medium">
+          You have been eliminated. Your remaining picks are shown for reference only.
+        </div>
+      )}
+
+      {hasUnsavedDrafts && !isEliminated && (
+        <div className="rounded-xl bg-amber-50 border border-amber-200 px-4 py-3 text-amber-800 text-sm font-medium">
+          You have unsaved picks — submit before the deadline!
+        </div>
+      )}
+
+      {success && (
+        <div className="rounded-xl bg-green-50 border border-green-200 px-4 py-3 text-green-700 text-sm font-medium">
+          Picks saved! A confirmation email is on its way.
+        </div>
+      )}
+
+      {error && (
+        <div className="rounded-xl bg-red-50 border border-red-200 px-4 py-3 text-red-700 text-sm">
+          {error}
+        </div>
+      )}
+
+      {[1, 2, 3, 4, 5, 6].map((round) => (
+        <WcRoundCard
+          key={round}
+          roundNumber={round}
+          fixtures={fixturesByRound[round] ?? []}
+          currentDraft={drafts[round] ?? null}
+          existingPick={wcPicks.find((p) => p.round_number === round) ?? null}
+          usedTeamIds={usedTeamIds}
+          onPickTeam={(fixtureId, teamId) =>
+            handlePickTeam(round, fixtureId, teamId)
+          }
+          isEliminated={isEliminated}
+        />
+      ))}
+
+      {!isEliminated && (
+        <Button
+          onClick={handleSubmit}
+          disabled={isSubmitting || !hasUnsavedDrafts}
+          className="w-full mt-2"
+          size="lg"
+        >
+          {isSubmitting ? (
+            <>
+              <Loader className="animate-spin mr-2 h-4 w-4" />
+              Saving...
+            </>
+          ) : (
+            'Save picks'
+          )}
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/app/(dashboard)/wc-picks-form.tsx
+++ b/app/(dashboard)/wc-picks-form.tsx
@@ -7,7 +7,7 @@ import { cn } from '@/lib/utils';
 import WcRoundCard from './wc-round-card';
 import { Button } from '@/components/ui/button';
 import { WcFixture, WcPick, PickDraft } from '@/lib/wc-definitions';
-import { WC_ROUND_DEADLINES } from '@/lib/wc-constants';
+import { WC_ROUND_DEADLINES, WC_TEAM_FLAGS } from '@/lib/wc-constants';
 
 interface WcPicksFormProps {
   wcPicks: WcPick[];
@@ -123,6 +123,16 @@ export default function WcPicksForm({
     };
     for (const f of wcFixtures) {
       if (map[f.round_number]) map[f.round_number].push(f);
+    }
+    return map;
+  }, [wcFixtures]);
+
+  // Map from team ID → flag emoji, built from fixture data
+  const teamIdToFlag = useMemo(() => {
+    const map: Record<number, string> = {};
+    for (const f of wcFixtures) {
+      if (f.home_team_name) map[f.home_team_id] = WC_TEAM_FLAGS[f.home_team_name] ?? '🏳';
+      if (f.away_team_name) map[f.away_team_id] = WC_TEAM_FLAGS[f.away_team_name] ?? '🏳';
     }
     return map;
   }, [wcFixtures]);
@@ -307,6 +317,35 @@ export default function WcPicksForm({
         </div>
       )}
 
+      {!isEliminated && (
+        <div className="flex flex-col gap-2">
+          <Button
+            onClick={handleSubmit}
+            disabled={isSubmitting || !hasUnsavedDrafts}
+            className="w-full"
+            size="lg"
+          >
+            {isSubmitting ? (
+              <>
+                <Loader className="animate-spin mr-2 h-4 w-4" />
+                Saving...
+              </>
+            ) : (
+              'Save picks'
+            )}
+          </Button>
+          <p className="text-xs text-muted-foreground text-center">
+            Issues submitting?{' '}
+            <a
+              href={`mailto:${process.env.NEXT_PUBLIC_MY_EMAIL_ADDRESS}?subject=World%20Cup%202026%20-%20Prediction%20Submission&body=Hi%2C%20please%20find%20my%20predictions%20below%3A%0A%0A`}
+              className="underline hover:text-foreground transition-colors"
+            >
+              Email your predictions instead
+            </a>
+          </p>
+        </div>
+      )}
+
       {/* Round navigation */}
       <div className="flex flex-col gap-2">
         <p className="text-xs text-muted-foreground text-center">
@@ -321,27 +360,38 @@ export default function WcPicksForm({
             <ChevronLeft className="h-4 w-4" />
           </button>
 
-          <div className="flex gap-2.5">
+          <div className="flex gap-2">
             {[1, 2, 3, 4, 5, 6].map((r) => {
               const existing = wcPicks.find((p) => p.round_number === r);
               const draft = drafts[r];
-              const dotColor =
-                existing?.is_correct === false ? 'bg-red-500' :
-                existing?.is_correct === true  ? 'bg-green-500' :
-                existing && draft && draft.picked_team_id === existing.picked_team_id ? 'bg-green-400' :
-                draft || (!draft && existing) ? 'bg-amber-400' :
-                'bg-gray-300';
+              const pickedId = draft?.picked_team_id ?? existing?.picked_team_id;
+              const flag = pickedId ? teamIdToFlag[pickedId] : null;
+
+              const borderColor =
+                existing?.is_correct === false ? 'border-red-500' :
+                existing?.is_correct === true  ? 'border-green-500' :
+                existing && draft && draft.picked_team_id === existing.picked_team_id ? 'border-green-400' :
+                draft || (!draft && existing) ? 'border-amber-400' :
+                'border-gray-200';
+
               return (
                 <button
                   key={r}
                   onClick={() => setActiveRound(r)}
                   aria-label={`Go to round ${r}`}
                   className={cn(
-                    'h-3 w-3 rounded-full transition-all',
-                    dotColor,
-                    r === activeRound && 'ring-2 ring-offset-2 ring-gray-400 scale-110'
+                    'h-9 w-9 rounded-full flex items-center justify-center transition-all',
+                    borderColor,
+                    flag ? 'bg-white' : 'bg-gray-100',
+                    r === activeRound ? 'border-4 scale-110' : 'border-2 opacity-60'
                   )}
-                />
+                >
+                  {flag ? (
+                    <span className="text-lg leading-none">{flag}</span>
+                  ) : (
+                    <span className="text-xs font-semibold text-gray-400">{r}</span>
+                  )}
+                </button>
               );
             })}
           </div>
@@ -369,23 +419,6 @@ export default function WcPicksForm({
         isEliminated={isEliminated}
       />
 
-      {!isEliminated && (
-        <Button
-          onClick={handleSubmit}
-          disabled={isSubmitting || !hasUnsavedDrafts}
-          className="w-full mt-2"
-          size="lg"
-        >
-          {isSubmitting ? (
-            <>
-              <Loader className="animate-spin mr-2 h-4 w-4" />
-              Saving...
-            </>
-          ) : (
-            'Save picks'
-          )}
-        </Button>
-      )}
     </div>
   );
 }

--- a/app/(dashboard)/wc-round-card.tsx
+++ b/app/(dashboard)/wc-round-card.tsx
@@ -168,8 +168,8 @@ export default function WcRoundCard({
               : 'text-muted-foreground'
         )}>
           {isLocked
-            ? 'Deadline for prediction / changes has passed'
-            : `Deadline for prediction / changes: ${formatDeadline(deadline)}`}
+            ? 'Deadline to make changes has passed'
+            : `Make changes by: ${formatDeadline(deadline)}`}
         </p>
       </CardHeader>
 

--- a/app/(dashboard)/wc-round-card.tsx
+++ b/app/(dashboard)/wc-round-card.tsx
@@ -99,6 +99,14 @@ function RoundStatusBadge({
       </Badge>
     );
   }
+  // User had a saved pick but cleared their draft — needs to re-select
+  if (!currentDraft && existingPick) {
+    return (
+      <Badge className="bg-amber-100 text-amber-800 border-amber-200 hover:bg-amber-100">
+        Pick a team to continue
+      </Badge>
+    );
+  }
   if (existingPick) {
     return (
       <Badge className="bg-green-100 text-green-800 border-green-200 hover:bg-green-100">

--- a/app/(dashboard)/wc-round-card.tsx
+++ b/app/(dashboard)/wc-round-card.tsx
@@ -130,6 +130,14 @@ export default function WcRoundCard({
   const isLocked = new Date() > deadline;
   const isInteractive = !isLocked && !isEliminated;
 
+  // True when the draft differs from what's saved (or one exists without the other)
+  const hasUnsavedChange =
+    !isLocked && (
+      (currentDraft && !existingPick) ||
+      (!currentDraft && !!existingPick) ||
+      (currentDraft && existingPick && currentDraft.picked_team_id !== existingPick.picked_team_id)
+    );
+
   // Group fixtures by group_name, sorted alphabetically
   const byGroup = fixtures.reduce<Record<string, WcFixture[]>>((acc, f) => {
     if (!acc[f.group_name]) acc[f.group_name] = [];
@@ -151,7 +159,14 @@ export default function WcRoundCard({
             currentDraft={currentDraft}
           />
         </div>
-        <p className="text-xs mt-1 text-red-500">
+        <p className={cn(
+          'text-xs mt-1',
+          isLocked
+            ? 'text-muted-foreground'
+            : hasUnsavedChange
+              ? 'text-red-500'
+              : 'text-muted-foreground'
+        )}>
           {isLocked
             ? 'Deadline for prediction / changes has passed'
             : `Deadline for prediction / changes: ${formatDeadline(deadline)}`}

--- a/app/(dashboard)/wc-round-card.tsx
+++ b/app/(dashboard)/wc-round-card.tsx
@@ -215,6 +215,7 @@ function FixtureRow({
         <TeamButton
           teamId={fixture.home_team_id}
           teamName={fixture.home_team_name}
+          isHome={true}
           isSelected={homeSelected}
           isUsedElsewhere={homeUsedElsewhere}
           isInteractive={isInteractive}
@@ -242,6 +243,7 @@ function FixtureRow({
         <TeamButton
           teamId={fixture.away_team_id}
           teamName={fixture.away_team_name}
+          isHome={false}
           isSelected={awaySelected}
           isUsedElsewhere={awayUsedElsewhere}
           isInteractive={isInteractive}
@@ -255,6 +257,7 @@ function FixtureRow({
 function TeamButton({
   teamId,
   teamName,
+  isHome,
   isSelected,
   isUsedElsewhere,
   isInteractive,
@@ -262,6 +265,7 @@ function TeamButton({
 }: {
   teamId: number;
   teamName: string;
+  isHome: boolean;
   isSelected: boolean;
   isUsedElsewhere: boolean;
   isInteractive: boolean;
@@ -274,7 +278,8 @@ function TeamButton({
       type="button"
       onClick={isUsedElsewhere || !isInteractive ? undefined : onClick}
       className={cn(
-        'flex items-center gap-1.5 px-2.5 py-2 rounded-lg border text-xs font-medium transition-colors flex-1 min-w-0 text-left',
+        'flex items-center gap-1.5 px-2.5 py-2 rounded-lg border text-xs font-medium transition-colors flex-1 min-w-0',
+        isHome ? 'flex-row-reverse text-right' : 'flex-row text-left',
         isSelected
           ? 'bg-blue-50 border-blue-500 border-2 text-blue-800'
           : isUsedElsewhere

--- a/app/(dashboard)/wc-round-card.tsx
+++ b/app/(dashboard)/wc-round-card.tsx
@@ -79,7 +79,7 @@ function RoundStatusBadge({
     return <Badge variant="secondary">Awaiting result</Badge>;
   }
   if (isLocked) {
-    return <Badge variant="secondary">Locked</Badge>;
+    return <Badge variant="secondary">No prediction made</Badge>;
   }
   if (
     currentDraft &&
@@ -88,25 +88,25 @@ function RoundStatusBadge({
   ) {
     return (
       <Badge className="bg-amber-100 text-amber-800 border-amber-200 hover:bg-amber-100">
-        Unsaved change
+        Prediction changed
       </Badge>
     );
   }
   if (currentDraft && !existingPick) {
     return (
       <Badge className="bg-amber-100 text-amber-800 border-amber-200 hover:bg-amber-100">
-        Unsaved
+        Prediction unsaved
       </Badge>
     );
   }
   if (existingPick) {
     return (
       <Badge className="bg-green-100 text-green-800 border-green-200 hover:bg-green-100">
-        Saved
+        Prediction saved
       </Badge>
     );
   }
-  return <Badge variant="outline">Open</Badge>;
+  return <Badge variant="outline">No prediction yet</Badge>;
 }
 
 export default function WcRoundCard({
@@ -162,7 +162,7 @@ export default function WcRoundCard({
               <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-2">
                 Group {group}
               </p>
-              <div className="flex flex-col gap-2">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 sm:gap-3">
                 {byGroup[group].map((fixture) => (
                   <FixtureRow
                     key={fixture.id}
@@ -203,39 +203,51 @@ function FixtureRow({
     usedTeamIds.has(fixture.away_team_id) && !awaySelected;
 
   return (
-    <div className="flex items-center gap-2">
-      <TeamButton
-        teamId={fixture.home_team_id}
-        teamName={fixture.home_team_name}
-        isSelected={homeSelected}
-        isUsedElsewhere={homeUsedElsewhere}
-        isInteractive={isInteractive}
-        onClick={() => onPickTeam(fixture.id, fixture.home_team_id)}
-      />
+    <div className="flex flex-col">
+      {/* Date/score header — desktop only (sits above the team buttons) */}
+      <p className="hidden sm:block text-xs text-muted-foreground text-center mb-1.5">
+        {fixture.is_complete
+          ? `${fixture.home_team_score}–${fixture.away_team_score}`
+          : formatKickoff(fixture.kickoff_time)}
+      </p>
 
-      <div className="flex flex-col items-center min-w-[3.5rem] text-center shrink-0">
-        {fixture.is_complete ? (
-          <span className="text-sm font-semibold text-gray-700">
-            {fixture.home_team_score}–{fixture.away_team_score}
+      <div className="flex items-center gap-2">
+        <TeamButton
+          teamId={fixture.home_team_id}
+          teamName={fixture.home_team_name}
+          isSelected={homeSelected}
+          isUsedElsewhere={homeUsedElsewhere}
+          isInteractive={isInteractive}
+          onClick={() => onPickTeam(fixture.id, fixture.home_team_id)}
+        />
+
+        {/* Centre column — score/date inline for mobile, just "vs" on desktop */}
+        <div className="flex flex-col items-center min-w-[3rem] text-center shrink-0">
+          <span className="text-xs text-muted-foreground">
+            {fixture.is_complete ? (
+              <span className="sm:hidden font-semibold text-gray-700">
+                {fixture.home_team_score}–{fixture.away_team_score}
+              </span>
+            ) : (
+              'vs'
+            )}
           </span>
-        ) : (
-          <>
-            <span className="text-xs text-muted-foreground">vs</span>
-            <span className="text-[10px] text-muted-foreground leading-tight">
+          {!fixture.is_complete && (
+            <span className="text-[10px] text-muted-foreground leading-tight sm:hidden">
               {formatKickoff(fixture.kickoff_time)}
             </span>
-          </>
-        )}
-      </div>
+          )}
+        </div>
 
-      <TeamButton
-        teamId={fixture.away_team_id}
-        teamName={fixture.away_team_name}
-        isSelected={awaySelected}
-        isUsedElsewhere={awayUsedElsewhere}
-        isInteractive={isInteractive}
-        onClick={() => onPickTeam(fixture.id, fixture.away_team_id)}
-      />
+        <TeamButton
+          teamId={fixture.away_team_id}
+          teamName={fixture.away_team_name}
+          isSelected={awaySelected}
+          isUsedElsewhere={awayUsedElsewhere}
+          isInteractive={isInteractive}
+          onClick={() => onPickTeam(fixture.id, fixture.away_team_id)}
+        />
+      </div>
     </div>
   );
 }

--- a/app/(dashboard)/wc-round-card.tsx
+++ b/app/(dashboard)/wc-round-card.tsx
@@ -1,0 +1,292 @@
+'use client';
+
+import { WcFixture, WcPick, PickDraft } from '@/lib/wc-definitions';
+import {
+  WC_ROUND_LABELS,
+  WC_ROUND_DEADLINES,
+  WC_TEAM_FLAGS
+} from '@/lib/wc-constants';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
+
+interface WcRoundCardProps {
+  roundNumber: number;
+  fixtures: WcFixture[];
+  currentDraft: PickDraft | null;
+  existingPick: WcPick | null;
+  usedTeamIds: Set<number>;
+  onPickTeam: (fixtureId: number, teamId: number) => void;
+  isEliminated: boolean;
+}
+
+function formatDate(date: Date, opts: Intl.DateTimeFormatOptions): string {
+  return date.toLocaleString('en-GB', { timeZone: 'Europe/London', ...opts });
+}
+
+function formatKickoff(isoString: string): string {
+  const d = new Date(isoString);
+  const day = formatDate(d, {
+    weekday: 'short',
+    day: 'numeric',
+    month: 'short'
+  });
+  const time = formatDate(d, { hour: '2-digit', minute: '2-digit' });
+  return `${day}, ${time}`;
+}
+
+function formatDeadline(date: Date): string {
+  return formatDate(date, {
+    weekday: 'short',
+    day: 'numeric',
+    month: 'short',
+    hour: '2-digit',
+    minute: '2-digit'
+  });
+}
+
+function RoundStatusBadge({
+  isLocked,
+  existingPick,
+  currentDraft
+}: {
+  isLocked: boolean;
+  existingPick: WcPick | null;
+  currentDraft: PickDraft | null;
+}) {
+  const isSettled = existingPick != null && existingPick.is_correct != null;
+
+  if (isSettled && existingPick?.is_correct === true) {
+    return (
+      <Badge className="bg-green-100 text-green-800 border-green-200 hover:bg-green-100">
+        ✓ Survived
+      </Badge>
+    );
+  }
+  if (isSettled && existingPick?.is_correct === false) {
+    return (
+      <Badge className="bg-red-100 text-red-800 border-red-200 hover:bg-red-100">
+        ✗ Eliminated
+      </Badge>
+    );
+  }
+  if (isLocked && existingPick) {
+    return <Badge variant="secondary">Awaiting result</Badge>;
+  }
+  if (isLocked) {
+    return <Badge variant="secondary">Locked</Badge>;
+  }
+  if (
+    currentDraft &&
+    existingPick &&
+    currentDraft.picked_team_id !== existingPick.picked_team_id
+  ) {
+    return (
+      <Badge className="bg-amber-100 text-amber-800 border-amber-200 hover:bg-amber-100">
+        Unsaved change
+      </Badge>
+    );
+  }
+  if (currentDraft && !existingPick) {
+    return (
+      <Badge className="bg-amber-100 text-amber-800 border-amber-200 hover:bg-amber-100">
+        Unsaved
+      </Badge>
+    );
+  }
+  if (existingPick) {
+    return (
+      <Badge className="bg-green-100 text-green-800 border-green-200 hover:bg-green-100">
+        Saved
+      </Badge>
+    );
+  }
+  return <Badge variant="outline">Open</Badge>;
+}
+
+export default function WcRoundCard({
+  roundNumber,
+  fixtures,
+  currentDraft,
+  existingPick,
+  usedTeamIds,
+  onPickTeam,
+  isEliminated
+}: WcRoundCardProps) {
+  const deadline = WC_ROUND_DEADLINES[roundNumber];
+  const isLocked = new Date() > deadline;
+  const isInteractive = !isLocked && !isEliminated;
+
+  // Group fixtures by group_name, sorted alphabetically
+  const byGroup = fixtures.reduce<Record<string, WcFixture[]>>((acc, f) => {
+    if (!acc[f.group_name]) acc[f.group_name] = [];
+    acc[f.group_name].push(f);
+    return acc;
+  }, {});
+  const sortedGroups = Object.keys(byGroup).sort();
+
+  return (
+    <Card className="rounded-xl bg-white shadow-sm overflow-hidden">
+      <CardHeader className="p-4 pb-2">
+        <div className="flex items-start justify-between gap-2 flex-wrap">
+          <CardTitle className="text-base font-semibold leading-tight">
+            {WC_ROUND_LABELS[roundNumber]}
+          </CardTitle>
+          <RoundStatusBadge
+            isLocked={isLocked}
+            existingPick={existingPick}
+            currentDraft={currentDraft}
+          />
+        </div>
+        <p
+          className={cn(
+            'text-xs mt-1',
+            isLocked ? 'text-red-500' : 'text-muted-foreground'
+          )}
+        >
+          {isLocked
+            ? 'Deadline passed'
+            : `Deadline: ${formatDeadline(deadline)}`}
+        </p>
+      </CardHeader>
+
+      <CardContent className="p-4 pt-2">
+        <div className="flex flex-col gap-4">
+          {sortedGroups.map((group) => (
+            <div key={group}>
+              <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-2">
+                Group {group}
+              </p>
+              <div className="flex flex-col gap-2">
+                {byGroup[group].map((fixture) => (
+                  <FixtureRow
+                    key={fixture.id}
+                    fixture={fixture}
+                    currentDraft={currentDraft}
+                    usedTeamIds={usedTeamIds}
+                    onPickTeam={onPickTeam}
+                    isInteractive={isInteractive}
+                  />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function FixtureRow({
+  fixture,
+  currentDraft,
+  usedTeamIds,
+  onPickTeam,
+  isInteractive
+}: {
+  fixture: WcFixture;
+  currentDraft: PickDraft | null;
+  usedTeamIds: Set<number>;
+  onPickTeam: (fixtureId: number, teamId: number) => void;
+  isInteractive: boolean;
+}) {
+  const homeSelected = currentDraft?.picked_team_id === fixture.home_team_id;
+  const awaySelected = currentDraft?.picked_team_id === fixture.away_team_id;
+  const homeUsedElsewhere =
+    usedTeamIds.has(fixture.home_team_id) && !homeSelected;
+  const awayUsedElsewhere =
+    usedTeamIds.has(fixture.away_team_id) && !awaySelected;
+
+  return (
+    <div className="flex items-center gap-2">
+      <TeamButton
+        teamId={fixture.home_team_id}
+        teamName={fixture.home_team_name}
+        isSelected={homeSelected}
+        isUsedElsewhere={homeUsedElsewhere}
+        isInteractive={isInteractive}
+        onClick={() => onPickTeam(fixture.id, fixture.home_team_id)}
+      />
+
+      <div className="flex flex-col items-center min-w-[3.5rem] text-center shrink-0">
+        {fixture.is_complete ? (
+          <span className="text-sm font-semibold text-gray-700">
+            {fixture.home_team_score}–{fixture.away_team_score}
+          </span>
+        ) : (
+          <>
+            <span className="text-xs text-muted-foreground">vs</span>
+            <span className="text-[10px] text-muted-foreground leading-tight">
+              {formatKickoff(fixture.kickoff_time)}
+            </span>
+          </>
+        )}
+      </div>
+
+      <TeamButton
+        teamId={fixture.away_team_id}
+        teamName={fixture.away_team_name}
+        isSelected={awaySelected}
+        isUsedElsewhere={awayUsedElsewhere}
+        isInteractive={isInteractive}
+        onClick={() => onPickTeam(fixture.id, fixture.away_team_id)}
+      />
+    </div>
+  );
+}
+
+function TeamButton({
+  teamId,
+  teamName,
+  isSelected,
+  isUsedElsewhere,
+  isInteractive,
+  onClick
+}: {
+  teamId: number;
+  teamName: string;
+  isSelected: boolean;
+  isUsedElsewhere: boolean;
+  isInteractive: boolean;
+  onClick: () => void;
+}) {
+  const flag = WC_TEAM_FLAGS[teamName] ?? '🏳';
+
+  const button = (
+    <button
+      type="button"
+      onClick={isUsedElsewhere || !isInteractive ? undefined : onClick}
+      className={cn(
+        'flex items-center gap-1.5 px-2.5 py-2 rounded-lg border text-xs font-medium transition-colors flex-1 min-w-0 text-left',
+        isSelected
+          ? 'bg-blue-50 border-blue-500 border-2 text-blue-800'
+          : isUsedElsewhere
+            ? 'bg-gray-100 border-gray-200 text-gray-400 cursor-not-allowed opacity-60'
+            : !isInteractive
+              ? 'bg-gray-50 border-gray-200 text-gray-500 cursor-default'
+              : 'bg-white border-gray-200 text-gray-700 hover:bg-gray-50 cursor-pointer'
+      )}
+    >
+      <span className="text-base leading-none shrink-0">{flag}</span>
+      <span className="truncate">{teamName}</span>
+    </button>
+  );
+
+  if (isUsedElsewhere) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild className="flex-1 min-w-0">
+          {button}
+        </TooltipTrigger>
+        <TooltipContent>Already used in another round</TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  return <>{button}</>;
+}

--- a/app/(dashboard)/wc-round-card.tsx
+++ b/app/(dashboard)/wc-round-card.tsx
@@ -143,15 +143,10 @@ export default function WcRoundCard({
             currentDraft={currentDraft}
           />
         </div>
-        <p
-          className={cn(
-            'text-xs mt-1',
-            isLocked ? 'text-red-500' : 'text-muted-foreground'
-          )}
-        >
+        <p className="text-xs mt-1 text-red-500">
           {isLocked
-            ? 'Deadline passed'
-            : `Deadline: ${formatDeadline(deadline)}`}
+            ? 'Deadline for prediction / changes has passed'
+            : `Deadline for prediction / changes: ${formatDeadline(deadline)}`}
         </p>
       </CardHeader>
 

--- a/app/(dashboard)/wc-round-card.tsx
+++ b/app/(dashboard)/wc-round-card.tsx
@@ -187,6 +187,7 @@ export default function WcRoundCard({
                     fixture={fixture}
                     currentDraft={currentDraft}
                     usedTeamIds={usedTeamIds}
+                    clearedPickTeamId={!currentDraft && existingPick ? existingPick.picked_team_id : null}
                     onPickTeam={onPickTeam}
                     isInteractive={isInteractive}
                   />
@@ -204,21 +205,27 @@ function FixtureRow({
   fixture,
   currentDraft,
   usedTeamIds,
+  clearedPickTeamId,
   onPickTeam,
   isInteractive
 }: {
   fixture: WcFixture;
   currentDraft: PickDraft | null;
   usedTeamIds: Set<number>;
+  clearedPickTeamId: number | null;
   onPickTeam: (fixtureId: number, teamId: number) => void;
   isInteractive: boolean;
 }) {
   const homeSelected = currentDraft?.picked_team_id === fixture.home_team_id;
   const awaySelected = currentDraft?.picked_team_id === fixture.away_team_id;
+  // Exclude the cleared pick team from "used elsewhere" within this round's card
+  // so the user can re-select it without it appearing greyed out.
   const homeUsedElsewhere =
-    usedTeamIds.has(fixture.home_team_id) && !homeSelected;
+    usedTeamIds.has(fixture.home_team_id) && !homeSelected &&
+    fixture.home_team_id !== clearedPickTeamId;
   const awayUsedElsewhere =
-    usedTeamIds.has(fixture.away_team_id) && !awaySelected;
+    usedTeamIds.has(fixture.away_team_id) && !awaySelected &&
+    fixture.away_team_id !== clearedPickTeamId;
 
   return (
     <div className="flex flex-col rounded-lg border border-gray-100 bg-gray-50 p-2">

--- a/app/(dashboard)/wc-round-card.tsx
+++ b/app/(dashboard)/wc-round-card.tsx
@@ -203,7 +203,7 @@ function FixtureRow({
     usedTeamIds.has(fixture.away_team_id) && !awaySelected;
 
   return (
-    <div className="flex flex-col">
+    <div className="flex flex-col rounded-lg border border-gray-100 bg-gray-50 p-2">
       {/* Date/score header — desktop only (sits above the team buttons) */}
       <p className="hidden sm:block text-xs text-muted-foreground text-center mb-1.5">
         {fixture.is_complete

--- a/app/api/wc/admin/route.ts
+++ b/app/api/wc/admin/route.ts
@@ -1,0 +1,93 @@
+import { sql } from '@vercel/postgres';
+
+// PATCH /api/wc/admin
+// Marks a fixture complete, records the score, and resolves all picks for it.
+// Body: { fixture_id: number, home_team_score: number, away_team_score: number }
+//
+// A pick is correct if the picked team won (higher score after 90 min).
+// Draws = everyone who picked either team is incorrect (only wins count).
+// Guarded by WC_ADMIN_SECRET header to prevent accidental use.
+
+export async function PATCH(request: Request) {
+  const secret = request.headers.get('x-admin-secret');
+  if (secret !== process.env.WC_ADMIN_SECRET) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const body = await request.json();
+    const { fixture_id, home_team_score, away_team_score } = body;
+
+    if (
+      typeof fixture_id !== 'number' ||
+      typeof home_team_score !== 'number' ||
+      typeof away_team_score !== 'number'
+    ) {
+      return Response.json(
+        { error: 'fixture_id, home_team_score and away_team_score are required numbers' },
+        { status: 400 }
+      );
+    }
+
+    // Fetch fixture to get team IDs
+    const { rows: fixtures } = await sql.query<{
+      home_team_id: number;
+      away_team_id: number;
+      is_complete: boolean;
+    }>(
+      `SELECT home_team_id, away_team_id, is_complete FROM wc_fixtures WHERE id = $1`,
+      [fixture_id]
+    );
+
+    if (!fixtures.length) {
+      return Response.json({ error: `Fixture ${fixture_id} not found` }, { status: 404 });
+    }
+
+    if (fixtures[0].is_complete) {
+      return Response.json(
+        { error: `Fixture ${fixture_id} is already marked complete` },
+        { status: 409 }
+      );
+    }
+
+    const { home_team_id, away_team_id } = fixtures[0];
+
+    // Determine winning team (null = draw, draws eliminate everyone)
+    const winner_team_id =
+      home_team_score > away_team_score
+        ? home_team_id
+        : away_team_score > home_team_score
+          ? away_team_id
+          : null;
+
+    // Update fixture with result
+    await sql.query(
+      `UPDATE wc_fixtures
+       SET home_team_score = $1, away_team_score = $2, is_complete = TRUE
+       WHERE id = $3`,
+      [home_team_score, away_team_score, fixture_id]
+    );
+
+    // Resolve all pending picks for this fixture
+    // A pick is correct only if the picked team won outright
+    const { rowCount } = await sql.query(
+      `UPDATE wc_picks
+       SET is_correct = (picked_team_id = $1)
+       WHERE fixture_id = $2
+         AND is_correct IS NULL`,
+      [winner_team_id ?? -1, fixture_id] // -1 means no winner → all picks = false
+    );
+
+    return Response.json({
+      success: true,
+      fixture_id,
+      home_team_score,
+      away_team_score,
+      winner_team_id,
+      picks_resolved: rowCount ?? 0
+    });
+  } catch (error) {
+    console.error('WC admin error:', error);
+    return Response.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/app/api/wc/fixtures/route.ts
+++ b/app/api/wc/fixtures/route.ts
@@ -1,0 +1,35 @@
+import { sql } from '@vercel/postgres';
+import { WcFixture } from '@/lib/wc-definitions';
+
+export async function GET() {
+  try {
+    const { rows } = await sql.query<WcFixture>(
+      `SELECT
+        f.id,
+        f.round_number,
+        f.group_name,
+        f.kickoff_time,
+        f.venue,
+        f.home_team_score,
+        f.away_team_score,
+        f.is_complete,
+        ht.id         AS home_team_id,
+        ht.name       AS home_team_name,
+        ht.short_name AS home_team_short,
+        at.id         AS away_team_id,
+        at.name       AS away_team_name,
+        at.short_name AS away_team_short
+      FROM wc_fixtures f
+      JOIN wc_teams ht ON ht.id = f.home_team_id
+      JOIN wc_teams at ON at.id = f.away_team_id
+      ORDER BY f.round_number, f.kickoff_time`
+    );
+
+    return Response.json(rows, {
+      headers: { 'Cache-Control': 's-maxage=300' }
+    });
+  } catch (error) {
+    console.error('Error fetching WC fixtures:', error);
+    return Response.json({ error: 'Failed to fetch fixtures' }, { status: 500 });
+  }
+}

--- a/app/api/wc/picks/route.ts
+++ b/app/api/wc/picks/route.ts
@@ -136,7 +136,7 @@ export async function POST(request: Request) {
     const replacedRounds = new Set(roundNumbers);
     const { rows: existingPicks } = await sql.query<{ round_number: number; picked_team_id: number }>(
       `SELECT round_number, picked_team_id FROM wc_picks
-       WHERE user_id = $1 AND league_id = $2 AND is_correct IS NULL`,
+       WHERE user_id = $1 AND league_id = $2`,
       [userId, league_id]
     );
     for (const existing of existingPicks) {

--- a/app/api/wc/picks/route.ts
+++ b/app/api/wc/picks/route.ts
@@ -13,6 +13,17 @@ export async function GET() {
   }
 
   try {
+    const leagueResult = await sql.query<{ league_id: number }>(
+      `SELECT league_id FROM user_leagues WHERE user_id = $1 LIMIT 1`,
+      [session.user.id]
+    );
+
+    if (!leagueResult.rows.length) {
+      return Response.json([]);
+    }
+
+    const { league_id } = leagueResult.rows[0];
+
     const { rows } = await sql.query<WcPick>(
       `SELECT
         p.round_number,
@@ -23,11 +34,9 @@ export async function GET() {
         p.last_amended_at
       FROM wc_picks p
       WHERE p.user_id = $1
-        AND p.league_id = (
-          SELECT league_id FROM user_leagues WHERE user_id = $1 LIMIT 1
-        )
+        AND p.league_id = $2
       ORDER BY p.round_number`,
-      [session.user.id]
+      [session.user.id, league_id]
     );
 
     return Response.json(rows);

--- a/app/api/wc/picks/route.ts
+++ b/app/api/wc/picks/route.ts
@@ -102,10 +102,10 @@ export async function POST(request: Request) {
       }
     }
 
-    // Validate each fixture_id exists and picked_team_id is a participant
+    // Validate each fixture_id exists, belongs to the correct round, and picked_team_id is a participant
     for (const pick of picks) {
-      const { rows } = await sql.query<{ home_team_id: number; away_team_id: number }>(
-        `SELECT home_team_id, away_team_id FROM wc_fixtures WHERE id = $1`,
+      const { rows } = await sql.query<{ home_team_id: number; away_team_id: number; round_number: number }>(
+        `SELECT home_team_id, away_team_id, round_number FROM wc_fixtures WHERE id = $1`,
         [pick.fixture_id]
       );
       if (!rows.length) {
@@ -114,7 +114,13 @@ export async function POST(request: Request) {
           { status: 400 }
         );
       }
-      const { home_team_id, away_team_id } = rows[0];
+      const { home_team_id, away_team_id, round_number: fixtureRound } = rows[0];
+      if (fixtureRound !== pick.round_number) {
+        return Response.json(
+          { error: `Fixture ${pick.fixture_id} does not belong to Round ${pick.round_number}` },
+          { status: 400 }
+        );
+      }
       if (pick.picked_team_id !== home_team_id && pick.picked_team_id !== away_team_id) {
         return Response.json(
           { error: `Team ${pick.picked_team_id} does not play in fixture ${pick.fixture_id}` },
@@ -183,18 +189,19 @@ export async function POST(request: Request) {
           .map((p) => `<li><strong>Round ${p.round_number}:</strong> ${teamNameById[p.picked_team_id]}</li>`)
           .join('');
 
+        const adminEmail = process.env.NEXT_PUBLIC_MY_EMAIL_ADDRESS;
         const resend = new Resend(process.env.AUTH_RESEND_KEY);
         await resend.emails.send({
           from: 'Last Player Standing <noreply@lmsiq.co.uk>',
           to: [userEmail],
-          bcc: [process.env.NEXT_PUBLIC_MY_EMAIL_ADDRESS || ''],
+          ...(adminEmail && { bcc: [adminEmail] }),
           subject: 'World Cup 2026 — picks submitted',
           html: `
             <h2>Hey ${userName} 👋🏻</h2>
             <p>Your World Cup 2026 picks have been saved!</p>
             <ul>${pickLines}</ul>
             <p>You can amend any pick up to 2 hours before that round's first kick-off.</p>
-            <p>If something looks wrong, email <a href="mailto:${process.env.NEXT_PUBLIC_MY_EMAIL_ADDRESS}">${process.env.NEXT_PUBLIC_MY_EMAIL_ADDRESS}</a></p>
+            ${adminEmail ? `<p>If something looks wrong, email <a href="mailto:${adminEmail}">${adminEmail}</a></p>` : ''}
           `
         });
       } catch (emailError) {

--- a/app/api/wc/picks/route.ts
+++ b/app/api/wc/picks/route.ts
@@ -1,0 +1,202 @@
+import { auth } from '@/lib/auth';
+import { sql } from '@vercel/postgres';
+import { Resend } from 'resend';
+import { WcPick } from '@/lib/wc-definitions';
+import { WC_ROUND_DEADLINES } from '@/lib/wc-constants';
+
+// ── GET: fetch current user's picks ──────────────────────────────────────────
+
+export async function GET() {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const { rows } = await sql.query<WcPick>(
+      `SELECT
+        p.round_number,
+        p.fixture_id,
+        p.picked_team_id,
+        p.is_correct,
+        p.submitted_at,
+        p.last_amended_at
+      FROM wc_picks p
+      WHERE p.user_id = $1
+        AND p.league_id = (
+          SELECT league_id FROM user_leagues WHERE user_id = $1 LIMIT 1
+        )
+      ORDER BY p.round_number`,
+      [session.user.id]
+    );
+
+    return Response.json(rows);
+  } catch (error) {
+    console.error('Error fetching WC picks:', error);
+    return Response.json({ error: 'Failed to fetch picks' }, { status: 500 });
+  }
+}
+
+// ── POST: submit / amend picks (all rounds at once) ───────────────────────────
+
+type PickInput = {
+  round_number: number;
+  fixture_id: number;
+  picked_team_id: number;
+};
+
+export async function POST(request: Request) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const userId = session.user.id;
+  const userEmail = session.user.email;
+  const userName = session.user.user_name || 'there';
+
+  try {
+    const body = await request.json();
+    const picks: PickInput[] = body.picks;
+
+    if (!Array.isArray(picks) || picks.length === 0) {
+      return Response.json({ error: 'No picks provided' }, { status: 400 });
+    }
+
+    // Resolve league_id
+    const leagueResult = await sql.query<{ league_id: number }>(
+      `SELECT league_id FROM user_leagues WHERE user_id = $1 LIMIT 1`,
+      [userId]
+    );
+    if (!leagueResult.rows.length) {
+      return Response.json({ error: 'User is not part of a league' }, { status: 400 });
+    }
+    const { league_id } = leagueResult.rows[0];
+
+    // Validate round numbers are in range and unique within the submission
+    const roundNumbers = picks.map((p) => p.round_number);
+    if (roundNumbers.some((r) => r < 1 || r > 6)) {
+      return Response.json({ error: 'Round number must be between 1 and 6' }, { status: 400 });
+    }
+    if (new Set(roundNumbers).size !== roundNumbers.length) {
+      return Response.json({ error: 'Duplicate round numbers in submission' }, { status: 400 });
+    }
+
+    // Check deadlines — reject any pick for a locked round
+    const now = new Date();
+    for (const pick of picks) {
+      if (now > WC_ROUND_DEADLINES[pick.round_number]) {
+        return Response.json(
+          { error: `Deadline has passed for Round ${pick.round_number}` },
+          { status: 400 }
+        );
+      }
+    }
+
+    // Validate each fixture_id exists and picked_team_id is a participant
+    for (const pick of picks) {
+      const { rows } = await sql.query<{ home_team_id: number; away_team_id: number }>(
+        `SELECT home_team_id, away_team_id FROM wc_fixtures WHERE id = $1`,
+        [pick.fixture_id]
+      );
+      if (!rows.length) {
+        return Response.json(
+          { error: `Fixture ${pick.fixture_id} not found` },
+          { status: 400 }
+        );
+      }
+      const { home_team_id, away_team_id } = rows[0];
+      if (pick.picked_team_id !== home_team_id && pick.picked_team_id !== away_team_id) {
+        return Response.json(
+          { error: `Team ${pick.picked_team_id} does not play in fixture ${pick.fixture_id}` },
+          { status: 400 }
+        );
+      }
+    }
+
+    // Cross-round uniqueness: no team can be picked twice across all submitted rounds
+    const submittedTeamIds = picks.map((p) => p.picked_team_id);
+    if (new Set(submittedTeamIds).size !== submittedTeamIds.length) {
+      return Response.json(
+        { error: 'The same team cannot be picked in more than one round' },
+        { status: 400 }
+      );
+    }
+
+    // Also check against existing picks for rounds NOT being replaced
+    const replacedRounds = new Set(roundNumbers);
+    const { rows: existingPicks } = await sql.query<{ round_number: number; picked_team_id: number }>(
+      `SELECT round_number, picked_team_id FROM wc_picks
+       WHERE user_id = $1 AND league_id = $2 AND is_correct IS NULL`,
+      [userId, league_id]
+    );
+    for (const existing of existingPicks) {
+      if (!replacedRounds.has(existing.round_number)) {
+        if (submittedTeamIds.includes(existing.picked_team_id)) {
+          return Response.json(
+            { error: `That team is already picked in Round ${existing.round_number}` },
+            { status: 400 }
+          );
+        }
+      }
+    }
+
+    // Upsert picks — never overwrite a settled pick (is_correct IS NOT NULL)
+    let savedCount = 0;
+    for (const pick of picks) {
+      const result = await sql.query(
+        `INSERT INTO wc_picks (user_id, league_id, round_number, fixture_id, picked_team_id)
+         VALUES ($1, $2, $3, $4, $5)
+         ON CONFLICT (user_id, league_id, round_number)
+         DO UPDATE SET
+           fixture_id     = EXCLUDED.fixture_id,
+           picked_team_id = EXCLUDED.picked_team_id,
+           last_amended_at = NOW()
+         WHERE wc_picks.is_correct IS NULL`,
+        [userId, league_id, pick.round_number, pick.fixture_id, pick.picked_team_id]
+      );
+      savedCount += result.rowCount ?? 0;
+    }
+
+    // Send confirmation email
+    if (userEmail) {
+      try {
+        // Fetch team names for the email summary
+        const teamIds = [...new Set(picks.map((p) => p.picked_team_id))];
+        const { rows: teamRows } = await sql.query<{ id: number; name: string }>(
+          `SELECT id, name FROM wc_teams WHERE id = ANY($1::int[])`,
+          [teamIds]
+        );
+        const teamNameById = Object.fromEntries(teamRows.map((t) => [t.id, t.name]));
+
+        const pickLines = picks
+          .sort((a, b) => a.round_number - b.round_number)
+          .map((p) => `<li><strong>Round ${p.round_number}:</strong> ${teamNameById[p.picked_team_id]}</li>`)
+          .join('');
+
+        const resend = new Resend(process.env.AUTH_RESEND_KEY);
+        await resend.emails.send({
+          from: 'Last Player Standing <noreply@lmsiq.co.uk>',
+          to: [userEmail],
+          bcc: [process.env.NEXT_PUBLIC_MY_EMAIL_ADDRESS || ''],
+          subject: 'World Cup 2026 — picks submitted',
+          html: `
+            <h2>Hey ${userName} 👋🏻</h2>
+            <p>Your World Cup 2026 picks have been saved!</p>
+            <ul>${pickLines}</ul>
+            <p>You can amend any pick up to 2 hours before that round's first kick-off.</p>
+            <p>If something looks wrong, email <a href="mailto:${process.env.NEXT_PUBLIC_MY_EMAIL_ADDRESS}">${process.env.NEXT_PUBLIC_MY_EMAIL_ADDRESS}</a></p>
+          `
+        });
+      } catch (emailError) {
+        // Don't fail the request if email sending fails
+        console.error('Failed to send WC picks confirmation email:', emailError);
+      }
+    }
+
+    return Response.json({ success: true, savedCount }, { status: 201 });
+  } catch (error) {
+    console.error('Error saving WC picks:', error);
+    return Response.json({ error: 'Failed to save picks' }, { status: 500 });
+  }
+}

--- a/app/api/wc/register-interest/route.ts
+++ b/app/api/wc/register-interest/route.ts
@@ -1,0 +1,38 @@
+import { Resend } from 'resend';
+import { WC_ROUND_DEADLINES } from '@/lib/wc-constants';
+
+export async function POST(request: Request) {
+  // Registration closes at the Round 1 deadline
+  if (new Date() >= WC_ROUND_DEADLINES[1]) {
+    return Response.json(
+      { error: 'Registration is closed — the game has already started.' },
+      { status: 403 }
+    );
+  }
+
+  try {
+    const { email } = await request.json();
+
+    if (!email || typeof email !== 'string' || !email.includes('@')) {
+      return Response.json({ error: 'A valid email address is required.' }, { status: 400 });
+    }
+
+    const resend = new Resend(process.env.AUTH_RESEND_KEY);
+
+    await resend.emails.send({
+      from: 'Last Player Standing <noreply@lmsiq.co.uk>',
+      to: [process.env.NEXT_PUBLIC_MY_EMAIL_ADDRESS || ''],
+      subject: `WC LPS: join request from ${email}`,
+      html: `
+        <h2>New join request</h2>
+        <p><strong>${email}</strong> has requested to join the World Cup 2026 Last Player Standing game.</p>
+        <p>Add them to the DB and league, then let them know they can log in and submit predictions.</p>
+      `
+    });
+
+    return Response.json({ success: true }, { status: 201 });
+  } catch (error) {
+    console.error('Error sending register-interest email:', error);
+    return Response.json({ error: 'Something went wrong. Please try again.' }, { status: 500 });
+  }
+}

--- a/app/api/wc/register-interest/route.ts
+++ b/app/api/wc/register-interest/route.ts
@@ -10,6 +10,12 @@ export async function POST(request: Request) {
     );
   }
 
+  const adminEmail = process.env.NEXT_PUBLIC_MY_EMAIL_ADDRESS;
+  if (!adminEmail) {
+    console.error('NEXT_PUBLIC_MY_EMAIL_ADDRESS is not configured');
+    return Response.json({ error: 'Server configuration error.' }, { status: 500 });
+  }
+
   try {
     const { email } = await request.json();
 
@@ -21,7 +27,7 @@ export async function POST(request: Request) {
 
     await resend.emails.send({
       from: 'Last Player Standing <noreply@lmsiq.co.uk>',
-      to: [process.env.NEXT_PUBLIC_MY_EMAIL_ADDRESS || ''],
+      to: [adminEmail],
       subject: `WC LPS: join request from ${email}`,
       html: `
         <h2>New join request</h2>

--- a/app/api/wc/seed/route.ts
+++ b/app/api/wc/seed/route.ts
@@ -1,0 +1,211 @@
+import { sql } from '@vercel/postgres';
+
+// All times in UTC (BST − 1hr)
+const TEAMS = [
+  // Group A
+  { name: 'Mexico',                  short_name: 'MEX', group_name: 'A' },
+  { name: 'South Africa',            short_name: 'RSA', group_name: 'A' },
+  { name: 'South Korea',             short_name: 'KOR', group_name: 'A' },
+  { name: 'Czechia',                 short_name: 'CZE', group_name: 'A' },
+  // Group B
+  { name: 'Canada',                  short_name: 'CAN', group_name: 'B' },
+  { name: 'Bosnia and Herzegovina',  short_name: 'BIH', group_name: 'B' },
+  { name: 'Qatar',                   short_name: 'QAT', group_name: 'B' },
+  { name: 'Switzerland',             short_name: 'SUI', group_name: 'B' },
+  // Group C
+  { name: 'Brazil',                  short_name: 'BRA', group_name: 'C' },
+  { name: 'Morocco',                 short_name: 'MAR', group_name: 'C' },
+  { name: 'Haiti',                   short_name: 'HAI', group_name: 'C' },
+  { name: 'Scotland',                short_name: 'SCO', group_name: 'C' },
+  // Group D
+  { name: 'USA',                     short_name: 'USA', group_name: 'D' },
+  { name: 'Paraguay',                short_name: 'PAR', group_name: 'D' },
+  { name: 'Australia',               short_name: 'AUS', group_name: 'D' },
+  { name: 'Türkiye',                 short_name: 'TUR', group_name: 'D' },
+  // Group E
+  { name: 'Germany',                 short_name: 'GER', group_name: 'E' },
+  { name: 'Curaçao',                 short_name: 'CUW', group_name: 'E' },
+  { name: 'Ivory Coast',             short_name: 'CIV', group_name: 'E' },
+  { name: 'Ecuador',                 short_name: 'ECU', group_name: 'E' },
+  // Group F
+  { name: 'Netherlands',             short_name: 'NED', group_name: 'F' },
+  { name: 'Japan',                   short_name: 'JPN', group_name: 'F' },
+  { name: 'Sweden',                  short_name: 'SWE', group_name: 'F' },
+  { name: 'Tunisia',                 short_name: 'TUN', group_name: 'F' },
+  // Group G
+  { name: 'Belgium',                 short_name: 'BEL', group_name: 'G' },
+  { name: 'Egypt',                   short_name: 'EGY', group_name: 'G' },
+  { name: 'Iran',                    short_name: 'IRN', group_name: 'G' },
+  { name: 'New Zealand',             short_name: 'NZL', group_name: 'G' },
+  // Group H
+  { name: 'Spain',                   short_name: 'ESP', group_name: 'H' },
+  { name: 'Cape Verde',              short_name: 'CPV', group_name: 'H' },
+  { name: 'Saudi Arabia',            short_name: 'KSA', group_name: 'H' },
+  { name: 'Uruguay',                 short_name: 'URU', group_name: 'H' },
+  // Group I
+  { name: 'France',                  short_name: 'FRA', group_name: 'I' },
+  { name: 'Senegal',                 short_name: 'SEN', group_name: 'I' },
+  { name: 'Iraq',                    short_name: 'IRQ', group_name: 'I' },
+  { name: 'Norway',                  short_name: 'NOR', group_name: 'I' },
+  // Group J
+  { name: 'Argentina',               short_name: 'ARG', group_name: 'J' },
+  { name: 'Algeria',                 short_name: 'ALG', group_name: 'J' },
+  { name: 'Austria',                 short_name: 'AUT', group_name: 'J' },
+  { name: 'Jordan',                  short_name: 'JOR', group_name: 'J' },
+  // Group K
+  { name: 'Portugal',                short_name: 'POR', group_name: 'K' },
+  { name: 'DR Congo',                short_name: 'COD', group_name: 'K' },
+  { name: 'Colombia',                short_name: 'COL', group_name: 'K' },
+  { name: 'Uzbekistan',              short_name: 'UZB', group_name: 'K' },
+  // Group L
+  { name: 'England',                 short_name: 'ENG', group_name: 'L' },
+  { name: 'Croatia',                 short_name: 'CRO', group_name: 'L' },
+  { name: 'Ghana',                   short_name: 'GHA', group_name: 'L' },
+  { name: 'Panama',                  short_name: 'PAN', group_name: 'L' },
+];
+
+// round_number maps to the 6 LPS game rounds:
+//   1 = Groups A–F Matchday 1  |  2 = Groups G–L Matchday 1
+//   3 = Groups A–F Matchday 2  |  4 = Groups G–L Matchday 2
+//   5 = Groups A–F Matchday 3  |  6 = Groups G–L Matchday 3
+const FIXTURES = [
+  // ── ROUND 1: Groups A–F, Matchday 1 ──────────────────────────────────
+  { round: 1, group: 'A', home: 'Mexico',                 away: 'South Africa',           ko: '2026-06-11T19:00:00Z' },
+  { round: 1, group: 'A', home: 'South Korea',            away: 'Czechia',                ko: '2026-06-12T02:00:00Z' },
+  { round: 1, group: 'B', home: 'Canada',                 away: 'Bosnia and Herzegovina', ko: '2026-06-12T19:00:00Z' },
+  { round: 1, group: 'B', home: 'Qatar',                  away: 'Switzerland',            ko: '2026-06-13T19:00:00Z' },
+  { round: 1, group: 'C', home: 'Brazil',                 away: 'Morocco',                ko: '2026-06-13T22:00:00Z' },
+  { round: 1, group: 'C', home: 'Haiti',                  away: 'Scotland',               ko: '2026-06-14T01:00:00Z' },
+  { round: 1, group: 'D', home: 'USA',                    away: 'Paraguay',               ko: '2026-06-13T01:00:00Z' },
+  { round: 1, group: 'D', home: 'Australia',              away: 'Türkiye',                ko: '2026-06-14T04:00:00Z' },
+  { round: 1, group: 'E', home: 'Germany',                away: 'Curaçao',                ko: '2026-06-14T17:00:00Z' },
+  { round: 1, group: 'E', home: 'Ivory Coast',            away: 'Ecuador',                ko: '2026-06-14T23:00:00Z' },
+  { round: 1, group: 'F', home: 'Netherlands',            away: 'Japan',                  ko: '2026-06-14T20:00:00Z' },
+  { round: 1, group: 'F', home: 'Sweden',                 away: 'Tunisia',                ko: '2026-06-15T02:00:00Z' },
+
+  // ── ROUND 2: Groups G–L, Matchday 1 ──────────────────────────────────
+  { round: 2, group: 'G', home: 'Belgium',                away: 'Egypt',                  ko: '2026-06-15T19:00:00Z' },
+  { round: 2, group: 'G', home: 'Iran',                   away: 'New Zealand',            ko: '2026-06-16T01:00:00Z' },
+  { round: 2, group: 'H', home: 'Spain',                  away: 'Cape Verde',             ko: '2026-06-15T16:00:00Z' },
+  { round: 2, group: 'H', home: 'Saudi Arabia',           away: 'Uruguay',                ko: '2026-06-15T22:00:00Z' },
+  { round: 2, group: 'I', home: 'France',                 away: 'Senegal',                ko: '2026-06-16T19:00:00Z' },
+  { round: 2, group: 'I', home: 'Iraq',                   away: 'Norway',                 ko: '2026-06-16T22:00:00Z' },
+  { round: 2, group: 'J', home: 'Argentina',              away: 'Algeria',                ko: '2026-06-17T01:00:00Z' },
+  { round: 2, group: 'J', home: 'Austria',                away: 'Jordan',                 ko: '2026-06-17T04:00:00Z' },
+  { round: 2, group: 'K', home: 'Portugal',               away: 'DR Congo',               ko: '2026-06-17T17:00:00Z' },
+  { round: 2, group: 'K', home: 'Uzbekistan',             away: 'Colombia',               ko: '2026-06-18T02:00:00Z' },
+  { round: 2, group: 'L', home: 'England',                away: 'Croatia',                ko: '2026-06-17T20:00:00Z' },
+  { round: 2, group: 'L', home: 'Ghana',                  away: 'Panama',                 ko: '2026-06-17T23:00:00Z' },
+
+  // ── ROUND 3: Groups A–F, Matchday 2 ──────────────────────────────────
+  { round: 3, group: 'A', home: 'Czechia',                away: 'South Africa',           ko: '2026-06-18T16:00:00Z' },
+  { round: 3, group: 'A', home: 'Mexico',                 away: 'South Korea',            ko: '2026-06-19T01:00:00Z' },
+  { round: 3, group: 'B', home: 'Switzerland',            away: 'Bosnia and Herzegovina', ko: '2026-06-18T19:00:00Z' },
+  { round: 3, group: 'B', home: 'Canada',                 away: 'Qatar',                  ko: '2026-06-18T22:00:00Z' },
+  { round: 3, group: 'C', home: 'Scotland',               away: 'Morocco',                ko: '2026-06-19T22:00:00Z' },
+  { round: 3, group: 'C', home: 'Brazil',                 away: 'Haiti',                  ko: '2026-06-20T00:30:00Z' },
+  { round: 3, group: 'D', home: 'USA',                    away: 'Australia',              ko: '2026-06-19T19:00:00Z' },
+  { round: 3, group: 'D', home: 'Türkiye',                away: 'Paraguay',               ko: '2026-06-20T03:00:00Z' },
+  { round: 3, group: 'E', home: 'Germany',                away: 'Ivory Coast',            ko: '2026-06-20T20:00:00Z' },
+  { round: 3, group: 'E', home: 'Ecuador',                away: 'Curaçao',                ko: '2026-06-21T00:00:00Z' },
+  { round: 3, group: 'F', home: 'Netherlands',            away: 'Sweden',                 ko: '2026-06-20T17:00:00Z' },
+  { round: 3, group: 'F', home: 'Tunisia',                away: 'Japan',                  ko: '2026-06-21T04:00:00Z' },
+
+  // ── ROUND 4: Groups G–L, Matchday 2 ──────────────────────────────────
+  { round: 4, group: 'G', home: 'Belgium',                away: 'Iran',                   ko: '2026-06-21T19:00:00Z' },
+  { round: 4, group: 'G', home: 'New Zealand',            away: 'Egypt',                  ko: '2026-06-22T01:00:00Z' },
+  { round: 4, group: 'H', home: 'Spain',                  away: 'Saudi Arabia',           ko: '2026-06-21T16:00:00Z' },
+  { round: 4, group: 'H', home: 'Uruguay',                away: 'Cape Verde',             ko: '2026-06-21T22:00:00Z' },
+  { round: 4, group: 'I', home: 'France',                 away: 'Iraq',                   ko: '2026-06-22T21:00:00Z' },
+  { round: 4, group: 'I', home: 'Norway',                 away: 'Senegal',                ko: '2026-06-23T00:00:00Z' },
+  { round: 4, group: 'J', home: 'Argentina',              away: 'Austria',                ko: '2026-06-22T17:00:00Z' },
+  { round: 4, group: 'J', home: 'Jordan',                 away: 'Algeria',                ko: '2026-06-23T03:00:00Z' },
+  { round: 4, group: 'K', home: 'Portugal',               away: 'Uzbekistan',             ko: '2026-06-23T17:00:00Z' },
+  { round: 4, group: 'K', home: 'Colombia',               away: 'DR Congo',               ko: '2026-06-24T02:00:00Z' },
+  { round: 4, group: 'L', home: 'England',                away: 'Ghana',                  ko: '2026-06-23T20:00:00Z' },
+  { round: 4, group: 'L', home: 'Panama',                 away: 'Croatia',                ko: '2026-06-23T23:00:00Z' },
+
+  // ── ROUND 5: Groups A–F, Matchday 3 ──────────────────────────────────
+  { round: 5, group: 'A', home: 'South Africa',           away: 'South Korea',            ko: '2026-06-25T01:00:00Z' },
+  { round: 5, group: 'A', home: 'Czechia',                away: 'Mexico',                 ko: '2026-06-25T01:00:00Z' },
+  { round: 5, group: 'B', home: 'Switzerland',            away: 'Canada',                 ko: '2026-06-24T19:00:00Z' },
+  { round: 5, group: 'B', home: 'Bosnia and Herzegovina', away: 'Qatar',                  ko: '2026-06-24T19:00:00Z' },
+  { round: 5, group: 'C', home: 'Morocco',                away: 'Haiti',                  ko: '2026-06-24T22:00:00Z' },
+  { round: 5, group: 'C', home: 'Scotland',               away: 'Brazil',                 ko: '2026-06-24T22:00:00Z' },
+  { round: 5, group: 'D', home: 'Türkiye',                away: 'USA',                    ko: '2026-06-26T02:00:00Z' },
+  { round: 5, group: 'D', home: 'Paraguay',               away: 'Australia',              ko: '2026-06-26T02:00:00Z' },
+  { round: 5, group: 'E', home: 'Curaçao',                away: 'Ivory Coast',            ko: '2026-06-25T20:00:00Z' },
+  { round: 5, group: 'E', home: 'Ecuador',                away: 'Germany',                ko: '2026-06-25T20:00:00Z' },
+  { round: 5, group: 'F', home: 'Tunisia',                away: 'Netherlands',            ko: '2026-06-25T23:00:00Z' },
+  { round: 5, group: 'F', home: 'Japan',                  away: 'Sweden',                 ko: '2026-06-25T23:00:00Z' },
+
+  // ── ROUND 6: Groups G–L, Matchday 3 ──────────────────────────────────
+  { round: 6, group: 'G', home: 'New Zealand',            away: 'Belgium',                ko: '2026-06-27T03:00:00Z' },
+  { round: 6, group: 'G', home: 'Egypt',                  away: 'Iran',                   ko: '2026-06-27T03:00:00Z' },
+  { round: 6, group: 'H', home: 'Cape Verde',             away: 'Saudi Arabia',           ko: '2026-06-27T00:00:00Z' },
+  { round: 6, group: 'H', home: 'Uruguay',                away: 'Spain',                  ko: '2026-06-27T00:00:00Z' },
+  { round: 6, group: 'I', home: 'Norway',                 away: 'France',                 ko: '2026-06-26T19:00:00Z' },
+  { round: 6, group: 'I', home: 'Senegal',                away: 'Iraq',                   ko: '2026-06-26T19:00:00Z' },
+  { round: 6, group: 'J', home: 'Algeria',                away: 'Austria',                ko: '2026-06-28T02:00:00Z' },
+  { round: 6, group: 'J', home: 'Jordan',                 away: 'Argentina',              ko: '2026-06-28T02:00:00Z' },
+  { round: 6, group: 'K', home: 'Colombia',               away: 'Portugal',               ko: '2026-06-27T23:30:00Z' },
+  { round: 6, group: 'K', home: 'DR Congo',               away: 'Uzbekistan',             ko: '2026-06-27T23:30:00Z' },
+  { round: 6, group: 'L', home: 'Panama',                 away: 'England',                ko: '2026-06-27T21:00:00Z' },
+  { round: 6, group: 'L', home: 'Croatia',                away: 'Ghana',                  ko: '2026-06-27T21:00:00Z' },
+];
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  if (searchParams.get('secret') !== process.env.WC_SEED_SECRET) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    // Clear existing data (fixtures first due to FK constraints)
+    await sql.query(`DELETE FROM wc_fixtures`);
+    await sql.query(`DELETE FROM wc_teams`);
+
+    // Insert teams
+    for (const team of TEAMS) {
+      await sql.query(
+        `INSERT INTO wc_teams (name, short_name, group_name) VALUES ($1, $2, $3)`,
+        [team.name, team.short_name, team.group_name]
+      );
+    }
+
+    // Build name → id lookup
+    const { rows: teamRows } = await sql.query<{ id: number; name: string }>(
+      `SELECT id, name FROM wc_teams`
+    );
+    const teamIdByName = Object.fromEntries(teamRows.map((r) => [r.name, r.id]));
+
+    // Verify all fixture team names resolve before inserting
+    for (const f of FIXTURES) {
+      if (!teamIdByName[f.home])
+        throw new Error(`Unknown team name in seed: "${f.home}"`);
+      if (!teamIdByName[f.away])
+        throw new Error(`Unknown team name in seed: "${f.away}"`);
+    }
+
+    // Insert fixtures
+    for (const f of FIXTURES) {
+      await sql.query(
+        `INSERT INTO wc_fixtures (round_number, group_name, home_team_id, away_team_id, kickoff_time)
+         VALUES ($1, $2, $3, $4, $5)`,
+        [f.round, f.group, teamIdByName[f.home], teamIdByName[f.away], f.ko]
+      );
+    }
+
+    return Response.json({
+      seeded: true,
+      teams: TEAMS.length,
+      fixtures: FIXTURES.length
+    });
+  } catch (error) {
+    console.error('WC seed error:', error);
+    return Response.json(
+      { error: error instanceof Error ? error.message : 'Seed failed' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/hooks/useWcFixtures.ts
+++ b/app/hooks/useWcFixtures.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+import { WcFixture } from '@/lib/wc-definitions';
+
+const useWcFixtures = () => {
+  const [wcFixtures, setWcFixtures] = useState<WcFixture[]>([]);
+  const [isLoadingWcFixtures, setIsLoadingWcFixtures] = useState(true);
+
+  useEffect(() => {
+    async function fetchFixtures() {
+      setIsLoadingWcFixtures(true);
+      const res = await fetch('/api/wc/fixtures');
+      if (!res.ok) {
+        setIsLoadingWcFixtures(false);
+        return;
+      }
+      const data = await res.json();
+      setWcFixtures(data);
+      setIsLoadingWcFixtures(false);
+    }
+
+    fetchFixtures();
+  }, []);
+
+  return { wcFixtures, isLoadingWcFixtures };
+};
+
+export default useWcFixtures;

--- a/app/hooks/useWcPicks.ts
+++ b/app/hooks/useWcPicks.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+import { WcPick } from '@/lib/wc-definitions';
+import { useSession } from 'next-auth/react';
+
+const useWcPicks = ({ refreshTrigger }: { refreshTrigger: number }) => {
+  const [wcPicks, setWcPicks] = useState<WcPick[]>([]);
+  const [isLoadingWcPicks, setIsLoadingWcPicks] = useState(true);
+
+  const { data: session } = useSession();
+
+  useEffect(() => {
+    async function fetchPicks() {
+      setIsLoadingWcPicks(true);
+      const res = await fetch('/api/wc/picks');
+      if (!res.ok) {
+        setIsLoadingWcPicks(false);
+        return;
+      }
+      const data = await res.json();
+      setWcPicks(data);
+      setIsLoadingWcPicks(false);
+    }
+
+    if (session) {
+      fetchPicks();
+    } else {
+      setIsLoadingWcPicks(false);
+    }
+  }, [refreshTrigger, session]);
+
+  return { wcPicks, isLoadingWcPicks };
+};
+
+export default useWcPicks;

--- a/app/hooks/useWcPicks.ts
+++ b/app/hooks/useWcPicks.ts
@@ -6,7 +6,7 @@ const useWcPicks = ({ refreshTrigger }: { refreshTrigger: number }) => {
   const [wcPicks, setWcPicks] = useState<WcPick[]>([]);
   const [isLoadingWcPicks, setIsLoadingWcPicks] = useState(true);
 
-  const { data: session } = useSession();
+  const { status } = useSession();
 
   useEffect(() => {
     async function fetchPicks() {
@@ -21,12 +21,16 @@ const useWcPicks = ({ refreshTrigger }: { refreshTrigger: number }) => {
       setIsLoadingWcPicks(false);
     }
 
-    if (session) {
+    // Keep loading=true while the session is still resolving so the consumer
+    // never sees a premature "loaded but empty" state.
+    if (status === 'loading') return;
+
+    if (status === 'authenticated') {
       fetchPicks();
     } else {
       setIsLoadingWcPicks(false);
     }
-  }, [refreshTrigger, session]);
+  }, [refreshTrigger, status]);
 
   return { wcPicks, isLoadingWcPicks };
 };

--- a/components/PickPlanner.tsx
+++ b/components/PickPlanner.tsx
@@ -24,7 +24,7 @@ import {
   TableRow
 } from '@/components/ui/table';
 import { FixturesData, Results } from '@/lib/definitions';
-import { TeamsArr } from 'app/(dashboard)/page';
+import { TeamsArr } from '@/lib/definitions';
 import { Session } from 'next-auth';
 
 // Constant - never changes

--- a/lib/definitions.ts
+++ b/lib/definitions.ts
@@ -99,3 +99,9 @@ export type Injury = {
   news: string;
   team_name: FPLTeamName | null;
 };
+
+export type TeamsArr = {
+  id: number;
+  name: FPLTeamName;
+  short_name: string;
+}[];

--- a/lib/wc-constants.ts
+++ b/lib/wc-constants.ts
@@ -1,10 +1,17 @@
 export const WC_ROUND_DEADLINES: Record<number, Date> = {
+  // Group stage
   1: new Date('2026-06-11T17:00:00Z'), // 6pm BST
   2: new Date('2026-06-15T14:00:00Z'), // 3pm BST
   3: new Date('2026-06-18T14:00:00Z'),
   4: new Date('2026-06-21T14:00:00Z'),
   5: new Date('2026-06-24T17:00:00Z'), // 6pm BST
-  6: new Date('2026-06-26T17:00:00Z')
+  6: new Date('2026-06-26T17:00:00Z'),
+  // Knockout stage
+  7:  new Date('2026-06-28T18:00:00Z'), // 7pm BST — Round of 32
+  8:  new Date('2026-07-04T16:00:00Z'), // 5pm BST — Round of 16
+  9:  new Date('2026-07-09T19:00:00Z'), // 8pm BST — Quarter-Finals
+  10: new Date('2026-07-14T18:00:00Z'), // 7pm BST — Semi-Finals
+  11: new Date('2026-07-19T18:00:00Z'), // 7pm BST — The Final
 };
 
 export const WC_ROUND_LABELS: Record<number, string> = {
@@ -13,7 +20,27 @@ export const WC_ROUND_LABELS: Record<number, string> = {
   3: 'Round 3 — Groups A–F, Matchday 2 (18–20 Jun)',
   4: 'Round 4 — Groups G–L, Matchday 2 (21–23 Jun)',
   5: 'Round 5 — Groups A–F, Matchday 3 (24–25 Jun)',
-  6: 'Round 6 — Groups G–L, Matchday 3 (26–27 Jun)'
+  6: 'Round 6 — Groups G–L, Matchday 3 (26–27 Jun)',
+  7:  'Round 7 — Round of 32',
+  8:  'Round 8 — Round of 16',
+  9:  'Round 9 — Quarter-Finals',
+  10: 'Round 10 — Semi-Finals',
+  11: 'Round 11 — The Final',
+};
+
+// Short fixture description for each round (used in rules tables)
+export const WC_ROUND_FIXTURE_LABELS: Record<number, string> = {
+  1: 'Groups A–F, Matchday 1',
+  2: 'Groups G–L, Matchday 1',
+  3: 'Groups A–F, Matchday 2',
+  4: 'Groups G–L, Matchday 2',
+  5: 'Groups A–F, Matchday 3',
+  6: 'Groups G–L, Matchday 3',
+  7:  'Round of 32',
+  8:  'Round of 16',
+  9:  'Quarter-Finals',
+  10: 'Semi-Finals',
+  11: 'The Final 🏆',
 };
 
 export const WC_ROUND_GROUPS: Record<number, string[]> = {

--- a/lib/wc-constants.ts
+++ b/lib/wc-constants.ts
@@ -1,0 +1,26 @@
+export const WC_ROUND_DEADLINES: Record<number, Date> = {
+  1: new Date('2026-06-11T17:00:00Z'), // 6pm BST
+  2: new Date('2026-06-15T14:00:00Z'), // 3pm BST
+  3: new Date('2026-06-18T14:00:00Z'),
+  4: new Date('2026-06-21T14:00:00Z'),
+  5: new Date('2026-06-24T17:00:00Z'), // 6pm BST
+  6: new Date('2026-06-26T17:00:00Z')
+};
+
+export const WC_ROUND_LABELS: Record<number, string> = {
+  1: 'Round 1 — Groups A–F, Matchday 1 (11–14 Jun)',
+  2: 'Round 2 — Groups G–L, Matchday 1 (15–17 Jun)',
+  3: 'Round 3 — Groups A–F, Matchday 2 (18–20 Jun)',
+  4: 'Round 4 — Groups G–L, Matchday 2 (21–23 Jun)',
+  5: 'Round 5 — Groups A–F, Matchday 3 (24–25 Jun)',
+  6: 'Round 6 — Groups G–L, Matchday 3 (26–27 Jun)'
+};
+
+export const WC_ROUND_GROUPS: Record<number, string[]> = {
+  1: ['A', 'B', 'C', 'D', 'E', 'F'],
+  2: ['G', 'H', 'I', 'J', 'K', 'L'],
+  3: ['A', 'B', 'C', 'D', 'E', 'F'],
+  4: ['G', 'H', 'I', 'J', 'K', 'L'],
+  5: ['A', 'B', 'C', 'D', 'E', 'F'],
+  6: ['G', 'H', 'I', 'J', 'K', 'L']
+};

--- a/lib/wc-constants.ts
+++ b/lib/wc-constants.ts
@@ -24,3 +24,66 @@ export const WC_ROUND_GROUPS: Record<number, string[]> = {
   5: ['A', 'B', 'C', 'D', 'E', 'F'],
   6: ['G', 'H', 'I', 'J', 'K', 'L']
 };
+
+export const WC_TEAM_FLAGS: Record<string, string> = {
+  // Group A
+  Czechia: '🇨🇿',
+  Mexico: '🇲🇽',
+  'South Africa': '🇿🇦',
+  'South Korea': '🇰🇷',
+  // Group B
+  Switzerland: '🇨🇭',
+  'Bosnia and Herzegovina': '🇧🇦',
+  Canada: '🇨🇦',
+  Qatar: '🇶🇦',
+  // Group C
+  Scotland: '🏴󠁧󠁢󠁳󠁣󠁴󠁿',
+  Brazil: '🇧🇷',
+  Haiti: '🇭🇹',
+  Morocco: '🇲🇦',
+  // Group D
+  Türkiye: '🇹🇷',
+  Paraguay: '🇵🇾',
+  USA: '🇺🇸',
+  Australia: '🇦🇺',
+  // Group E
+  Germany: '🇩🇪',
+  Ecuador: '🇪🇨',
+  'Ivory Coast': '🇨🇮',
+  Curaçao: '🇨🇼',
+  // Group F
+  Sweden: '🇸🇪',
+  Netherlands: '🇳🇱',
+  Tunisia: '🇹🇳',
+  Japan: '🇯🇵',
+  // Group G
+  Belgium: '🇧🇪',
+  Egypt: '🇪🇬',
+  Iran: '🇮🇷',
+  'New Zealand': '🇳🇿',
+  // Group H
+  Spain: '🇪🇸',
+  Uruguay: '🇺🇾',
+  'Cape Verde': '🇨🇻',
+  'Saudi Arabia': '🇸🇦',
+  // Group I
+  France: '🇫🇷',
+  Norway: '🇳🇴',
+  Senegal: '🇸🇳',
+  Iraq: '🇮🇶',
+  // Group J
+  Austria: '🇦🇹',
+  Argentina: '🇦🇷',
+  Algeria: '🇩🇿',
+  Jordan: '🇯🇴',
+  // Group K
+  Portugal: '🇵🇹',
+  Colombia: '🇨🇴',
+  'DR Congo': '🇨🇩',
+  Uzbekistan: '🇺🇿',
+  // Group L
+  Croatia: '🇭🇷',
+  England: '🏴󠁧󠁢󠁥󠁮󠁧󠁿',
+  Ghana: '🇬🇭',
+  Panama: '🇵🇦'
+};

--- a/lib/wc-definitions.ts
+++ b/lib/wc-definitions.ts
@@ -1,0 +1,40 @@
+export type WcFixture = {
+  id: number;
+  round_number: number;
+  group_name: string;
+  home_team_id: number;
+  home_team_name: string;
+  home_team_short: string;
+  home_team_flag: string | null;
+  away_team_id: number;
+  away_team_name: string;
+  away_team_short: string;
+  away_team_flag: string | null;
+  kickoff_time: string;
+  venue: string | null;
+  home_team_score: number | null;
+  away_team_score: number | null;
+  is_complete: boolean;
+};
+
+export type WcTeam = {
+  id: number;
+  name: string;
+  short_name: string;
+  group_name: string;
+  flag_emoji: string | null;
+};
+
+export type WcPick = {
+  round_number: number;
+  fixture_id: number;
+  picked_team_id: number;
+  is_correct: boolean | null;
+  submitted_at: string;
+  last_amended_at: string | null;
+};
+
+export type PickDraft = {
+  fixture_id: number;
+  picked_team_id: number;
+};

--- a/lib/wc-definitions.ts
+++ b/lib/wc-definitions.ts
@@ -22,7 +22,6 @@ export type WcTeam = {
   name: string;
   short_name: string;
   group_name: string;
-  flag_emoji: string | null;
 };
 
 export type WcPick = {

--- a/lib/wc-definitions.ts
+++ b/lib/wc-definitions.ts
@@ -5,11 +5,9 @@ export type WcFixture = {
   home_team_id: number;
   home_team_name: string;
   home_team_short: string;
-  home_team_flag: string | null;
   away_team_id: number;
   away_team_name: string;
   away_team_short: string;
-  away_team_flag: string | null;
   kickoff_time: string;
   venue: string | null;
   home_team_score: number | null;


### PR DESCRIPTION
## World Cup 2026 — Last Player Standing game

Temporary summer revamp of the site while the Premier League season is on hiatus. Replaces the FPL dashboard with a World Cup 2026 game for the duration of the tournament. All existing FPL code is preserved as comments and can be restored after the summer.

## What's in this PR

### Game format
- **Group stage (Rounds 1–6):** Last Player Standing. Each round, pick one team to win their match outright from a set of 12 fixtures. Can't reuse a team across rounds. Submit all 6 picks upfront and amend until the round deadline.
- **Knockout stage (Rounds 7–11):** Points-based score prediction — everyone predicts the score of the same predetermined match each round. 5pts correct score, 2pts correct result. Highest total after The Final wins. *(UI deferred — coming ~28 June)*

### Database
4 new tables created manually in Vercel Postgres:
- `wc_teams` — 48 national teams
- `wc_fixtures` — 72 group stage fixtures across 6 rounds
- `wc_picks` — user picks per round per league
- `wc_knockout_picks` — stub, empty until knockout stage is built

### New pages & components
- **3-tab homepage** — Rules (default), Group Stage, Knockout
- **Rules tab** — full game explanation, round/deadline tables for all 11 rounds, register interest form for guests
- **Group Stage tab** — one-round-at-a-time picks form with flag emoji navigation dots, auto-advance on pick, persistent status banner, save button + mailto fallback
- **Knockout tab** — coming soon placeholder

### API routes
| Route | Purpose |
|---|---|
| `GET /api/wc/fixtures` | All fixtures with team names (public) |
| `GET /api/wc/picks` | Authenticated user's picks |
| `POST /api/wc/picks` | Submit/amend picks with full server-side validation |
| `PATCH /api/wc/admin` | Mark fixture result + resolve picks (guarded by `WC_ADMIN_SECRET`) |
| `POST /api/wc/register-interest` | Guest email capture → admin notification (closes at Round 1 deadline) |
| `GET /api/wc/seed` | Seed teams + fixtures (guarded by `WC_SEED_SECRET`) |

### Guest experience
Unauthenticated users see the round card greyed out with a register interest form. Registration closes automatically at the Round 1 deadline (11 Jun, 6pm BST).

## Pre-deploy checklist
- [x] `WC_SEED_SECRET` set in Vercel environment variables
- [x] Seed endpoint run: `GET /api/wc/seed?secret=...`
- [x] Test a pick submission end-to-end

## Notes
- The `onPickTeam` prop in `wc-round-card.tsx` triggers a `ts(71007)` Next.js lint warning — this is a false positive (both components are client components, no server boundary) and is not blocking

🤖 Generated with [[Claude Code](https://claude.com/claude-code)](https://claude.com/claude-code)