### PR TITLE
Add admin results-entry UI at /admin

### DIFF
--- a/app/(dashboard)/admin/admin-results-form.tsx
+++ b/app/(dashboard)/admin/admin-results-form.tsx
@@ -56,7 +56,7 @@ export default function AdminResultsForm({
     }
     return init;
   });
-  const [submitting, setSubmitting] = useState<number | null>(null);
+  const [submitting, setSubmitting] = useState<Set<number>>(new Set());
   const [feedback, setFeedback] = useState<Record<number, Feedback>>({});
 
   // Round numbers present in the data, ascending (knockout rounds appear once seeded)
@@ -130,7 +130,7 @@ export default function AdminResultsForm({
 
     const home = Number(draft.home);
     const away = Number(draft.away);
-    setSubmitting(fixture.id);
+    setSubmitting((prev) => new Set(prev).add(fixture.id));
     try {
       const res = await fetch('/api/wc/admin', {
         method: 'PATCH',
@@ -167,13 +167,14 @@ export default function AdminResultsForm({
         )
       );
       const verb = result.was_complete ? 'Corrected' : 'Saved';
+      const noun = result.was_complete ? 're-resolved' : 'resolved';
       setFeedback((prev) => ({
         ...prev,
         [fixture.id]: {
           type: 'success',
           msg: `${verb} ${home}–${away} · ${result.picks_resolved} pick${
             result.picks_resolved === 1 ? '' : 's'
-          } resolved`
+          } ${noun}`
         }
       }));
     } catch {
@@ -182,7 +183,11 @@ export default function AdminResultsForm({
         [fixture.id]: { type: 'error', msg: 'Network error — try again.' }
       }));
     } finally {
-      setSubmitting(null);
+      setSubmitting((prev) => {
+        const next = new Set(prev);
+        next.delete(fixture.id);
+        return next;
+      });
     }
   }
 
@@ -235,7 +240,7 @@ export default function AdminResultsForm({
                   fixture={fixture}
                   draft={scores[fixture.id]}
                   feedback={feedback[fixture.id]}
-                  submitting={submitting === fixture.id}
+                  submitting={submitting.has(fixture.id)}
                   onScore={setScore}
                   onSubmit={submitFixture}
                 />

--- a/app/(dashboard)/admin/admin-results-form.tsx
+++ b/app/(dashboard)/admin/admin-results-form.tsx
@@ -1,0 +1,372 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import Link from 'next/link';
+import { Loader2 } from 'lucide-react';
+import { WcFixture, WcAdminResultResponse } from '@/lib/wc-definitions';
+import { WC_ROUND_FIXTURE_LABELS, WC_TEAM_FLAGS } from '@/lib/wc-constants';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+
+type ScoreDraft = { home: string; away: string };
+type Feedback = { type: 'success' | 'error'; msg: string };
+
+function londonDateStr(d: Date): string {
+  // en-CA gives YYYY-MM-DD, which sorts/compares lexicographically
+  return d.toLocaleDateString('en-CA', { timeZone: 'Europe/London' });
+}
+
+function formatKickoff(isoString: string): string {
+  const d = new Date(isoString);
+  const day = d.toLocaleString('en-GB', {
+    timeZone: 'Europe/London',
+    weekday: 'short',
+    day: 'numeric',
+    month: 'short'
+  });
+  const time = d.toLocaleString('en-GB', {
+    timeZone: 'Europe/London',
+    hour: '2-digit',
+    minute: '2-digit'
+  });
+  return `${day}, ${time}`;
+}
+
+function isValidScore(v: string): boolean {
+  return /^\d+$/.test(v.trim());
+}
+
+export default function AdminResultsForm({
+  fixtures: initialFixtures
+}: {
+  fixtures: WcFixture[];
+}) {
+  const [fixtures, setFixtures] = useState<WcFixture[]>(initialFixtures);
+  const [scores, setScores] = useState<Record<number, ScoreDraft>>(() => {
+    const init: Record<number, ScoreDraft> = {};
+    for (const f of initialFixtures) {
+      if (f.is_complete) {
+        init[f.id] = {
+          home: String(f.home_team_score ?? ''),
+          away: String(f.away_team_score ?? '')
+        };
+      }
+    }
+    return init;
+  });
+  const [submitting, setSubmitting] = useState<number | null>(null);
+  const [feedback, setFeedback] = useState<Record<number, Feedback>>({});
+
+  // Round numbers present in the data, ascending (knockout rounds appear once seeded)
+  const rounds = useMemo(
+    () =>
+      [...new Set(fixtures.map((f) => f.round_number))].sort((a, b) => a - b),
+    [fixtures]
+  );
+
+  const [selectedRound, setSelectedRound] = useState<number>(() => {
+    const today = londonDateStr(new Date());
+    const sorted = [
+      ...new Set(initialFixtures.map((f) => f.round_number))
+    ].sort((a, b) => a - b);
+    // Lowest round with an incomplete fixture kicking off today or earlier
+    const live = sorted.find((r) =>
+      initialFixtures.some(
+        (f) =>
+          f.round_number === r &&
+          !f.is_complete &&
+          londonDateStr(new Date(f.kickoff_time)) <= today
+      )
+    );
+    if (live != null) return live;
+    // Else the first round with any incomplete fixture
+    const pending = sorted.find((r) =>
+      initialFixtures.some((f) => f.round_number === r && !f.is_complete)
+    );
+    return pending ?? sorted[0] ?? 1;
+  });
+
+  const roundFixtures = fixtures.filter(
+    (f) => f.round_number === selectedRound
+  );
+
+  // Group by group_name, sorted alphabetically
+  const byGroup = roundFixtures.reduce<Record<string, WcFixture[]>>(
+    (acc, f) => {
+      (acc[f.group_name] ??= []).push(f);
+      return acc;
+    },
+    {}
+  );
+  const sortedGroups = Object.keys(byGroup).sort();
+
+  function setScore(fixtureId: number, side: 'home' | 'away', value: string) {
+    // Keep digits only; allow empty while typing
+    const cleaned = value.replace(/[^\d]/g, '');
+    setScores((prev) => {
+      const existing = prev[fixtureId] ?? { home: '', away: '' };
+      return { ...prev, [fixtureId]: { ...existing, [side]: cleaned } };
+    });
+    // Clear stale feedback once the score is edited again
+    setFeedback((prev) => {
+      if (!prev[fixtureId]) return prev;
+      const next = { ...prev };
+      delete next[fixtureId];
+      return next;
+    });
+  }
+
+  async function submitFixture(fixture: WcFixture) {
+    const draft = scores[fixture.id];
+    if (!draft || !isValidScore(draft.home) || !isValidScore(draft.away)) {
+      setFeedback((prev) => ({
+        ...prev,
+        [fixture.id]: { type: 'error', msg: 'Enter both scores (0 or more).' }
+      }));
+      return;
+    }
+
+    const home = Number(draft.home);
+    const away = Number(draft.away);
+    setSubmitting(fixture.id);
+    try {
+      const res = await fetch('/api/wc/admin', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          fixture_id: fixture.id,
+          home_team_score: home,
+          away_team_score: away
+        })
+      });
+      const data: WcAdminResultResponse | { error?: string } = await res.json();
+      if (!res.ok) {
+        setFeedback((prev) => ({
+          ...prev,
+          [fixture.id]: {
+            type: 'error',
+            msg: ('error' in data && data.error) || 'Failed to save result.'
+          }
+        }));
+        return;
+      }
+
+      const result = data as WcAdminResultResponse;
+      setFixtures((prev) =>
+        prev.map((f) =>
+          f.id === fixture.id
+            ? {
+                ...f,
+                home_team_score: home,
+                away_team_score: away,
+                is_complete: true
+              }
+            : f
+        )
+      );
+      const verb = result.was_complete ? 'Corrected' : 'Saved';
+      setFeedback((prev) => ({
+        ...prev,
+        [fixture.id]: {
+          type: 'success',
+          msg: `${verb} ${home}–${away} · ${result.picks_resolved} pick${
+            result.picks_resolved === 1 ? '' : 's'
+          } resolved`
+        }
+      }));
+    } catch {
+      setFeedback((prev) => ({
+        ...prev,
+        [fixture.id]: { type: 'error', msg: 'Network error — try again.' }
+      }));
+    } finally {
+      setSubmitting(null);
+    }
+  }
+
+  return (
+    <main className="mx-auto max-w-2xl p-4 sm:p-6">
+      <div className="mb-4">
+        <Link
+          href="/"
+          className="text-xs text-muted-foreground hover:underline"
+        >
+          ← Back to site
+        </Link>
+        <h1 className="mt-1 text-lg font-semibold">Admin — results entry</h1>
+        <p className="text-xs text-muted-foreground">
+          Tap in a score and save. Saved fixtures can be corrected by editing
+          and saving again.
+        </p>
+      </div>
+
+      {/* Round selector — scrollable on narrow screens */}
+      <div className="-mx-4 mb-4 flex gap-2 overflow-x-auto px-4 pb-1 sm:mx-0 sm:flex-wrap sm:px-0">
+        {rounds.map((r) => (
+          <Button
+            key={r}
+            type="button"
+            size="sm"
+            variant={r === selectedRound ? 'default' : 'outline'}
+            className="shrink-0"
+            onClick={() => setSelectedRound(r)}
+          >
+            R{r}
+          </Button>
+        ))}
+      </div>
+
+      <p className="mb-3 text-sm font-medium">
+        {WC_ROUND_FIXTURE_LABELS[selectedRound] ?? `Round ${selectedRound}`}
+      </p>
+
+      <div className="flex flex-col gap-5">
+        {sortedGroups.map((group) => (
+          <div key={group}>
+            <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Group {group}
+            </p>
+            <div className="flex flex-col gap-2">
+              {byGroup[group].map((fixture) => (
+                <FixtureRow
+                  key={fixture.id}
+                  fixture={fixture}
+                  draft={scores[fixture.id]}
+                  feedback={feedback[fixture.id]}
+                  submitting={submitting === fixture.id}
+                  onScore={setScore}
+                  onSubmit={submitFixture}
+                />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </main>
+  );
+}
+
+function ScoreInput({
+  value,
+  onChange,
+  disabled,
+  label
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  disabled: boolean;
+  label: string;
+}) {
+  return (
+    <Input
+      type="text"
+      inputMode="numeric"
+      pattern="[0-9]*"
+      maxLength={2}
+      aria-label={label}
+      value={value}
+      disabled={disabled}
+      onChange={(e) => onChange(e.target.value)}
+      className="h-10 w-12 text-center text-base"
+    />
+  );
+}
+
+function FixtureRow({
+  fixture,
+  draft,
+  feedback,
+  submitting,
+  onScore,
+  onSubmit
+}: {
+  fixture: WcFixture;
+  draft: ScoreDraft | undefined;
+  feedback: Feedback | undefined;
+  submitting: boolean;
+  onScore: (fixtureId: number, side: 'home' | 'away', value: string) => void;
+  onSubmit: (fixture: WcFixture) => void;
+}) {
+  const home = draft?.home ?? '';
+  const away = draft?.away ?? '';
+  const canSubmit = isValidScore(home) && isValidScore(away) && !submitting;
+  const homeFlag = WC_TEAM_FLAGS[fixture.home_team_name] ?? '🏳';
+  const awayFlag = WC_TEAM_FLAGS[fixture.away_team_name] ?? '🏳';
+
+  return (
+    <div className="rounded-lg border border-gray-100 bg-gray-50 p-2.5">
+      <div className="mb-2 flex items-center justify-between">
+        <span className="text-[11px] text-muted-foreground">
+          {formatKickoff(fixture.kickoff_time)}
+        </span>
+        {fixture.is_complete && (
+          <Badge className="border-green-200 bg-green-100 text-green-800 hover:bg-green-100">
+            Complete
+          </Badge>
+        )}
+      </div>
+
+      <div className="flex items-center gap-2">
+        {/* Home */}
+        <div className="flex min-w-0 flex-1 items-center justify-end gap-1.5 text-right">
+          <span className="truncate text-sm font-medium">
+            {fixture.home_team_short}
+          </span>
+          <span className="shrink-0 text-base leading-none">{homeFlag}</span>
+        </div>
+
+        <ScoreInput
+          value={home}
+          disabled={submitting}
+          onChange={(v) => onScore(fixture.id, 'home', v)}
+          label={`${fixture.home_team_name} score`}
+        />
+        <span className="text-muted-foreground">–</span>
+        <ScoreInput
+          value={away}
+          disabled={submitting}
+          onChange={(v) => onScore(fixture.id, 'away', v)}
+          label={`${fixture.away_team_name} score`}
+        />
+
+        {/* Away */}
+        <div className="flex min-w-0 flex-1 items-center gap-1.5">
+          <span className="shrink-0 text-base leading-none">{awayFlag}</span>
+          <span className="truncate text-sm font-medium">
+            {fixture.away_team_short}
+          </span>
+        </div>
+      </div>
+
+      <div className="mt-2 flex items-center justify-between gap-2">
+        <span
+          className={cn(
+            'min-w-0 flex-1 truncate text-xs',
+            feedback?.type === 'success' && 'text-green-700',
+            feedback?.type === 'error' && 'text-red-600',
+            !feedback && 'text-transparent'
+          )}
+        >
+          {feedback?.msg ?? '·'}
+        </span>
+        <Button
+          type="button"
+          size="sm"
+          disabled={!canSubmit}
+          onClick={() => onSubmit(fixture)}
+          className="shrink-0"
+        >
+          {submitting ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : fixture.is_complete ? (
+            'Update'
+          ) : (
+            'Save'
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/app/(dashboard)/admin/page.tsx
+++ b/app/(dashboard)/admin/page.tsx
@@ -1,0 +1,49 @@
+import { redirect } from 'next/navigation';
+import { sql } from '@vercel/postgres';
+import { auth } from '@/lib/auth';
+import { isAdminEmail } from '@/lib/admin';
+import { WcFixture } from '@/lib/wc-definitions';
+import AdminResultsForm from './admin-results-form';
+
+// Hidden admin page for entering fixture results. Not linked from the nav —
+// non-admins are redirected home. Fixtures are fetched with direct SQL
+// (not /api/wc/fixtures) so results entered moments ago aren't hidden by
+// that route's 5-minute edge cache.
+
+export default async function AdminPage() {
+  const session = await auth();
+  if (!isAdminEmail(session?.user?.email)) {
+    redirect('/');
+  }
+
+  const { rows } = await sql.query<WcFixture>(
+    `SELECT
+      f.id,
+      f.round_number,
+      f.group_name,
+      f.kickoff_time,
+      f.venue,
+      f.home_team_score,
+      f.away_team_score,
+      f.is_complete,
+      ht.id         AS home_team_id,
+      ht.name       AS home_team_name,
+      ht.short_name AS home_team_short,
+      at.id         AS away_team_id,
+      at.name       AS away_team_name,
+      at.short_name AS away_team_short
+    FROM wc_fixtures f
+    JOIN wc_teams ht ON ht.id = f.home_team_id
+    JOIN wc_teams at ON at.id = f.away_team_id
+    ORDER BY f.round_number, f.kickoff_time`
+  );
+
+  // Raw sql returns kickoff_time as a Date; WcFixture (and the client
+  // component boundary) needs a string
+  const fixtures = rows.map((f) => ({
+    ...f,
+    kickoff_time: new Date(f.kickoff_time).toISOString()
+  }));
+
+  return <AdminResultsForm fixtures={fixtures} />;
+}

--- a/app/api/wc/admin/route.ts
+++ b/app/api/wc/admin/route.ts
@@ -1,4 +1,4 @@
-import { sql } from '@vercel/postgres';
+import { sql, db } from '@vercel/postgres';
 import { auth } from '@/lib/auth';
 import { isAdminEmail } from '@/lib/admin';
 
@@ -25,12 +25,14 @@ export async function PATCH(request: Request) {
     const { fixture_id, home_team_score, away_team_score } = body;
 
     if (
-      typeof fixture_id !== 'number' ||
-      typeof home_team_score !== 'number' ||
-      typeof away_team_score !== 'number'
+      !Number.isInteger(fixture_id) ||
+      !Number.isInteger(home_team_score) ||
+      !Number.isInteger(away_team_score) ||
+      home_team_score < 0 ||
+      away_team_score < 0
     ) {
       return Response.json(
-        { error: 'fixture_id, home_team_score and away_team_score are required numbers' },
+        { error: 'fixture_id and non-negative integer scores are required' },
         { status: 400 }
       );
     }
@@ -46,10 +48,17 @@ export async function PATCH(request: Request) {
     );
 
     if (!fixtures.length) {
-      return Response.json({ error: `Fixture ${fixture_id} not found` }, { status: 404 });
+      return Response.json(
+        { error: `Fixture ${fixture_id} not found` },
+        { status: 404 }
+      );
     }
 
-    const { home_team_id, away_team_id, is_complete: was_complete } = fixtures[0];
+    const {
+      home_team_id,
+      away_team_id,
+      is_complete: was_complete
+    } = fixtures[0];
 
     // Determine winning team (null = draw, draws eliminate everyone)
     const winner_team_id =
@@ -59,23 +68,35 @@ export async function PATCH(request: Request) {
           ? away_team_id
           : null;
 
-    // Update fixture with result
-    await sql.query(
-      `UPDATE wc_fixtures
-       SET home_team_score = $1, away_team_score = $2, is_complete = TRUE
-       WHERE id = $3`,
-      [home_team_score, away_team_score, fixture_id]
-    );
-
-    // Resolve all picks for this fixture, recomputing from scratch so a
-    // corrected score also corrects previously-resolved picks
-    // A pick is correct only if the picked team won outright
-    const { rowCount } = await sql.query(
-      `UPDATE wc_picks
-       SET is_correct = (picked_team_id = $1)
-       WHERE fixture_id = $2`,
-      [winner_team_id ?? -1, fixture_id] // -1 means no winner → all picks = false
-    );
+    // Atomically record the result and re-resolve picks so we can't end up
+    // with a completed fixture whose picks were never updated.
+    // Picks are recomputed from scratch so a corrected score also corrects
+    // previously-resolved picks; a pick is correct only if the picked team
+    // won outright.
+    const client = await db.connect();
+    let rowCount = 0;
+    try {
+      await client.query('BEGIN');
+      await client.query(
+        `UPDATE wc_fixtures
+         SET home_team_score = $1, away_team_score = $2, is_complete = TRUE
+         WHERE id = $3`,
+        [home_team_score, away_team_score, fixture_id]
+      );
+      const picks = await client.query(
+        `UPDATE wc_picks
+         SET is_correct = (picked_team_id = $1)
+         WHERE fixture_id = $2`,
+        [winner_team_id ?? -1, fixture_id] // -1 means no winner → all picks = false
+      );
+      rowCount = picks.rowCount ?? 0;
+      await client.query('COMMIT');
+    } catch (e) {
+      await client.query('ROLLBACK');
+      throw e; // bubbles to the outer catch → 500
+    } finally {
+      client.release();
+    }
 
     return Response.json({
       success: true,

--- a/app/api/wc/admin/route.ts
+++ b/app/api/wc/admin/route.ts
@@ -1,17 +1,23 @@
 import { sql } from '@vercel/postgres';
+import { auth } from '@/lib/auth';
+import { isAdminEmail } from '@/lib/admin';
 
 // PATCH /api/wc/admin
-// Marks a fixture complete, records the score, and resolves all picks for it.
+// Records a fixture score, marks it complete, and resolves all picks for it.
+// Re-submitting a completed fixture overwrites the score and re-resolves picks.
 // Body: { fixture_id: number, home_team_score: number, away_team_score: number }
 //
 // A pick is correct if the picked team won (higher score after 90 min).
 // Draws = everyone who picked either team is incorrect (only wins count).
-// Guarded by WC_ADMIN_SECRET header to prevent accidental use.
+// Auth: WC_ADMIN_SECRET header (curl) or a signed-in admin session (/admin UI).
 
 export async function PATCH(request: Request) {
   const secret = request.headers.get('x-admin-secret');
   if (secret !== process.env.WC_ADMIN_SECRET) {
-    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+    const session = await auth();
+    if (!isAdminEmail(session?.user?.email)) {
+      return Response.json({ error: 'Unauthorized' }, { status: 401 });
+    }
   }
 
   try {
@@ -43,14 +49,7 @@ export async function PATCH(request: Request) {
       return Response.json({ error: `Fixture ${fixture_id} not found` }, { status: 404 });
     }
 
-    if (fixtures[0].is_complete) {
-      return Response.json(
-        { error: `Fixture ${fixture_id} is already marked complete` },
-        { status: 409 }
-      );
-    }
-
-    const { home_team_id, away_team_id } = fixtures[0];
+    const { home_team_id, away_team_id, is_complete: was_complete } = fixtures[0];
 
     // Determine winning team (null = draw, draws eliminate everyone)
     const winner_team_id =
@@ -68,13 +67,13 @@ export async function PATCH(request: Request) {
       [home_team_score, away_team_score, fixture_id]
     );
 
-    // Resolve all pending picks for this fixture
+    // Resolve all picks for this fixture, recomputing from scratch so a
+    // corrected score also corrects previously-resolved picks
     // A pick is correct only if the picked team won outright
     const { rowCount } = await sql.query(
       `UPDATE wc_picks
        SET is_correct = (picked_team_id = $1)
-       WHERE fixture_id = $2
-         AND is_correct IS NULL`,
+       WHERE fixture_id = $2`,
       [winner_team_id ?? -1, fixture_id] // -1 means no winner → all picks = false
     );
 
@@ -84,7 +83,8 @@ export async function PATCH(request: Request) {
       home_team_score,
       away_team_score,
       winner_team_id,
-      picks_resolved: rowCount ?? 0
+      picks_resolved: rowCount ?? 0,
+      was_complete
     });
   } catch (error) {
     console.error('WC admin error:', error);

--- a/lib/admin.ts
+++ b/lib/admin.ts
@@ -1,0 +1,9 @@
+// Identifies the site admin by email. Security rests on the NextAuth
+// magic-link session — the email itself is already public (used in
+// mailto links), so NEXT_PUBLIC_ exposure is fine.
+export function isAdminEmail(email: string | null | undefined): boolean {
+  const adminEmail = process.env.NEXT_PUBLIC_MY_EMAIL_ADDRESS;
+  return (
+    !!adminEmail && !!email && email.toLowerCase() === adminEmail.toLowerCase()
+  );
+}

--- a/lib/wc-definitions.ts
+++ b/lib/wc-definitions.ts
@@ -43,6 +43,7 @@ export type WcAdminResultResponse = {
   home_team_score: number;
   away_team_score: number;
   winner_team_id: number | null;
+  // Count of all picks on this fixture that were (re-)resolved by this request
   picks_resolved: number;
   was_complete: boolean;
 };

--- a/lib/wc-definitions.ts
+++ b/lib/wc-definitions.ts
@@ -35,3 +35,14 @@ export type PickDraft = {
   fixture_id: number;
   picked_team_id: number;
 };
+
+// Response from PATCH /api/wc/admin after recording a fixture result
+export type WcAdminResultResponse = {
+  success: boolean;
+  fixture_id: number;
+  home_team_score: number;
+  away_team_score: number;
+  winner_team_id: number | null;
+  picks_resolved: number;
+  was_complete: boolean;
+};


### PR DESCRIPTION
## What & why

Entering World Cup results currently means hitting `PATCH /api/wc/admin` by hand with curl, an `x-admin-secret` header, and a `fixture_id` you have to look up — impractical from a phone during match days. This adds a hidden, mobile-first `/admin` page to enter and correct results by tapping in scores.

## Changes

- **`isAdminEmail()` helper** (`lib/admin.ts`) — identifies the admin by comparing the session email to `NEXT_PUBLIC_MY_EMAIL_ADDRESS` (case-insensitive, fails closed if unset). Security rests on the NextAuth magic-link session, not the email's secrecy.
- **Dual auth on `/api/wc/admin`** — accepts the existing `x-admin-secret` header (curl keeps working) **or** a signed-in admin session (the new UI). 
- **Corrections allowed** — re-submitting a completed fixture overwrites the score and re-resolves *all* picks for it (dropped the `is_correct IS NULL` filter and the 409); response gains `was_complete`.
- **`/admin` page** (`app/(dashboard)/admin/`) — server component gates on the admin email and redirects non-admins to `/`. Fixtures are fetched with direct SQL to bypass the fixtures route's 5-minute edge cache, so freshly-entered results show immediately. The mobile-first form derives rounds from the data, defaults to the live round, and offers per-fixture Save/Update with inline feedback.

## Post-review hardening (commit `8dd312f`)

- Reject negative / non-integer scores (closes a decimal→500 path and bad-data writes).
- Wrap the fixture + picks updates in a transaction so a completed fixture can't be left with unresolved picks.
- Clarify the success message ("re-resolved" on a correction) and document the `picks_resolved` count.
- Track in-flight submits as a `Set` so concurrent saves don't share one spinner.

## Reviewer notes

- The admin email is `NEXT_PUBLIC_` and therefore in the client bundle — this is intentional and pre-existing (it's already used in mailto links); the actual gate is the session.
- A correction can flip picks from incorrect back to correct, intentionally "un-eliminating" a player when a wrong result is fixed.
- Verified manually in the browser (non-admin redirect, result entry, correction, mobile layout); `tsc` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)