### PR TITLE
Add Opta win-probability bar under each WC fixture

### DIFF
--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -279,6 +279,9 @@ const Page = () => {
             refreshTrigger={refreshTrigger}
             setRefreshTrigger={setRefreshTrigger}
           />
+          <p className="text-xs text-muted-foreground text-center mt-4">
+            Probabilities are from Opta
+          </p>
         </TabsContent>
 
         {/* ── Knockout tab ───────────────────────────────────────────────── */}

--- a/app/(dashboard)/wc-round-card.tsx
+++ b/app/(dashboard)/wc-round-card.tsx
@@ -275,6 +275,36 @@ function FixtureRow({
           onClick={() => onPickTeam(fixture.id, fixture.away_team_id)}
         />
       </div>
+
+      <WinProbabilityBar fixture={fixture} />
+    </div>
+  );
+}
+
+function WinProbabilityBar({ fixture }: { fixture: WcFixture }) {
+  const home = fixture.home_win_probability;
+  const away = fixture.away_win_probability;
+  // Missing or partial data → render nothing; card identical to before
+  if (home == null || away == null) return null;
+
+  const draw = Math.max(0, Math.round((100 - home - away) * 10) / 10);
+
+  return (
+    <div className="mt-1.5">
+      <div
+        role="img"
+        aria-label={`Win probability: ${fixture.home_team_name} ${home}%, draw ${draw}%, ${fixture.away_team_name} ${away}%`}
+        className="flex h-1.5 w-full gap-0.5 overflow-hidden rounded-full"
+      >
+        <div className="basis-0 rounded-full bg-blue-500" style={{ flexGrow: home }} />
+        <div className="basis-0 rounded-full bg-gray-300" style={{ flexGrow: draw }} />
+        <div className="basis-0 rounded-full bg-rose-400" style={{ flexGrow: away }} />
+      </div>
+      <div aria-hidden="true" className="mt-0.5 grid grid-cols-3 text-[10px]">
+        <span className="text-left font-medium text-blue-600">{home}%</span>
+        <span className="text-center text-muted-foreground">Draw {draw}%</span>
+        <span className="text-right font-medium text-rose-600">{away}%</span>
+      </div>
     </div>
   );
 }

--- a/app/api/wc/fixtures/route.ts
+++ b/app/api/wc/fixtures/route.ts
@@ -13,6 +13,8 @@ export async function GET() {
         f.home_team_score,
         f.away_team_score,
         f.is_complete,
+        f.home_win_probability::float AS home_win_probability,
+        f.away_win_probability::float AS away_win_probability,
         ht.id         AS home_team_id,
         ht.name       AS home_team_name,
         ht.short_name AS home_team_short,

--- a/lib/wc-definitions.ts
+++ b/lib/wc-definitions.ts
@@ -13,6 +13,8 @@ export type WcFixture = {
   home_team_score: number | null;
   away_team_score: number | null;
   is_complete: boolean;
+  home_win_probability: number | null;
+  away_win_probability: number | null;
 };
 
 export type WcTeam = {


### PR DESCRIPTION
## What

Adds a thin 3-segment probability bar (home win / draw / away win) beneath each group-stage fixture on the Group Stage tab, showing Opta's pre-match win probabilities.

![bar: home% | draw% | away% with small labels underneath]

## Why

Gives players useful context on each matchup when making their picks. Opta data is also worth keeping as a record to look back on.

## How

- **Data lives on `wc_fixtures`.** Two new nullable `NUMERIC(4,1)` columns — `home_win_probability` / `away_win_probability` — added manually via `ALTER TABLE` (the owner populates them ad hoc as Opta publishes, ~days ahead, keyed by team name). No separate table / join — `wc_fixtures` is the single source of truth.
- **API:** `/api/wc/fixtures` selects the two columns with `::float`, so node-postgres returns JS numbers rather than `NUMERIC` strings (`NULL` preserved).
- **UI:** new `WinProbabilityBar` in `wc-round-card.tsx` derives the draw as `100 − home − away`, sizes segments with `flex-grow` ratios (overflow-proof, 0% collapses cleanly), and renders **nothing** when either value is absent — so fixtures without Opta data look exactly as before. Bar persists after a result is entered (retrospective view).
- Attribution note "Probabilities are from Opta" on the Group Stage tab.

## Reviewer notes

- **DB migration required before this is live:** `ALTER TABLE wc_fixtures ADD COLUMN home_win_probability NUMERIC(4,1), ADD COLUMN away_win_probability NUMERIC(4,1);` — the fixtures query references these columns, so it errors until they exist.
- Re-running `/api/wc/seed` would wipe these columns (and scores); the seed is effectively retired mid-tournament.
- Accessibility: bar is `role="img"` with a full-sentence `aria-label`; the visual percentage labels are `aria-hidden` to avoid duplicate announcements.
- Probabilities are entered manually keyed off team **name** (ids are non-obvious); team spellings must match `wc_teams.name` (Türkiye, Curaçao, USA, South Korea, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)