### PR TITLE
Fix: locked-round deadline blocking saves for open rounds

### DIFF
--- a/app/(dashboard)/wc-picks-form.tsx
+++ b/app/(dashboard)/wc-picks-form.tsx
@@ -165,21 +165,20 @@ export default function WcPicksForm({
 
   const isEliminated = wcPicks.some((p) => p.is_correct === false);
 
-  const hasUnsavedDrafts = useMemo(
-    () =>
-      Object.entries(drafts).some(([roundStr, draft]) => {
-        if (!draft) return false;
-        const existing = wcPicks.find(
-          (p) => p.round_number === Number(roundStr)
-        );
-        if (!existing) return true;
-        return (
-          existing.picked_team_id !== draft.picked_team_id ||
-          existing.fixture_id !== draft.fixture_id
-        );
-      }),
-    [drafts, wcPicks]
-  );
+  const hasUnsavedDrafts = useMemo(() => {
+    const now = new Date();
+    return Object.entries(drafts).some(([roundStr, draft]) => {
+      if (!draft) return false;
+      const round = Number(roundStr);
+      if (now > WC_ROUND_DEADLINES[round]) return false;
+      const existing = wcPicks.find((p) => p.round_number === round);
+      if (!existing) return true;
+      return (
+        existing.picked_team_id !== draft.picked_team_id ||
+        existing.fixture_id !== draft.fixture_id
+      );
+    });
+  }, [drafts, wcPicks]);
 
   const statusBanner = useMemo(() => {
     if (isEliminated) return null; // has its own banner
@@ -254,8 +253,12 @@ export default function WcPicksForm({
     setIsSubmitting(true);
     setError(null);
 
+    const now = new Date();
     const picks = Object.entries(drafts)
-      .filter(([, draft]) => draft !== null)
+      .filter(([roundStr, draft]) => {
+        if (!draft) return false;
+        return now < WC_ROUND_DEADLINES[Number(roundStr)];
+      })
       .map(([roundStr, draft]) => ({
         round_number: Number(roundStr),
         fixture_id: draft!.fixture_id,

--- a/app/(dashboard)/wc-picks-form.tsx
+++ b/app/(dashboard)/wc-picks-form.tsx
@@ -15,6 +15,7 @@ import WcRoundCard from './wc-round-card';
 import { Button } from '@/components/ui/button';
 import { WcFixture, WcPick, PickDraft } from '@/lib/wc-definitions';
 import { WC_ROUND_DEADLINES, WC_TEAM_FLAGS } from '@/lib/wc-constants';
+import { buildSubmittablePicks, computeHasUnsavedDrafts } from './wc-picks-utils';
 
 interface WcPicksFormProps {
   wcPicks: WcPick[];
@@ -165,20 +166,10 @@ export default function WcPicksForm({
 
   const isEliminated = wcPicks.some((p) => p.is_correct === false);
 
-  const hasUnsavedDrafts = useMemo(() => {
-    const now = new Date();
-    return Object.entries(drafts).some(([roundStr, draft]) => {
-      if (!draft) return false;
-      const round = Number(roundStr);
-      if (now > WC_ROUND_DEADLINES[round]) return false;
-      const existing = wcPicks.find((p) => p.round_number === round);
-      if (!existing) return true;
-      return (
-        existing.picked_team_id !== draft.picked_team_id ||
-        existing.fixture_id !== draft.fixture_id
-      );
-    });
-  }, [drafts, wcPicks]);
+  const hasUnsavedDrafts = useMemo(
+    () => computeHasUnsavedDrafts(drafts, wcPicks, WC_ROUND_DEADLINES),
+    [drafts, wcPicks]
+  );
 
   const statusBanner = useMemo(() => {
     if (isEliminated) return null; // has its own banner
@@ -253,17 +244,7 @@ export default function WcPicksForm({
     setIsSubmitting(true);
     setError(null);
 
-    const now = new Date();
-    const picks = Object.entries(drafts)
-      .filter(([roundStr, draft]) => {
-        if (!draft) return false;
-        return now < WC_ROUND_DEADLINES[Number(roundStr)];
-      })
-      .map(([roundStr, draft]) => ({
-        round_number: Number(roundStr),
-        fixture_id: draft!.fixture_id,
-        picked_team_id: draft!.picked_team_id
-      }));
+    const picks = buildSubmittablePicks(drafts, WC_ROUND_DEADLINES);
 
     if (picks.length === 0) {
       setError('No picks selected.');

--- a/app/(dashboard)/wc-picks-utils.test.ts
+++ b/app/(dashboard)/wc-picks-utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   buildSubmittablePicks,
   computeHasUnsavedDrafts
@@ -59,7 +59,33 @@ describe('buildSubmittablePicks', () => {
 
     expect(result).toHaveLength(1);
     expect(result[0].round_number).toBe(6);
+    expect(result[0].fixture_id).toBe(106);
     expect(result[0].picked_team_id).toBe(6);
+  });
+
+  it('includes a round whose deadline is exactly now (matches server boundary)', () => {
+    const now = new Date('2026-06-26T17:00:00Z');
+    const drafts: Record<number, PickDraft | null> = {
+      1: null,
+      2: null,
+      3: null,
+      4: null,
+      5: null,
+      6: makeDraft(106, 6)
+    };
+    // Round 6 deadline == now; server rejects only when now > deadline, so this
+    // should still be submittable.
+    const deadlines: Record<number, Date> = { ...MIXED_DEADLINES, 6: now };
+
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    try {
+      const result = buildSubmittablePicks(drafts, deadlines);
+      expect(result).toHaveLength(1);
+      expect(result[0].round_number).toBe(6);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('includes all rounds when all deadlines are in the future', () => {

--- a/app/(dashboard)/wc-picks-utils.test.ts
+++ b/app/(dashboard)/wc-picks-utils.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildSubmittablePicks,
+  computeHasUnsavedDrafts
+} from './wc-picks-utils';
+import { PickDraft, WcPick } from '@/lib/wc-definitions';
+
+const PAST = new Date('2020-01-01T00:00:00Z');
+const FUTURE = new Date('2099-01-01T00:00:00Z');
+
+// Deadlines where rounds 1–5 are locked and round 6 is open
+const MIXED_DEADLINES: Record<number, Date> = {
+  1: PAST,
+  2: PAST,
+  3: PAST,
+  4: PAST,
+  5: PAST,
+  6: FUTURE
+};
+
+const ALL_OPEN_DEADLINES: Record<number, Date> = {
+  1: FUTURE,
+  2: FUTURE,
+  3: FUTURE,
+  4: FUTURE,
+  5: FUTURE,
+  6: FUTURE
+};
+
+function makeDraft(fixtureId: number, teamId: number): PickDraft {
+  return { fixture_id: fixtureId, picked_team_id: teamId };
+}
+
+function makePick(round: number, fixtureId: number, teamId: number): WcPick {
+  return {
+    round_number: round,
+    fixture_id: fixtureId,
+    picked_team_id: teamId,
+    is_correct: null,
+    submitted_at: '2026-06-01T00:00:00Z',
+    last_amended_at: null
+  };
+}
+
+// ── buildSubmittablePicks ─────────────────────────────────────────────────────
+
+describe('buildSubmittablePicks', () => {
+  it('excludes picks for rounds past their deadline', () => {
+    const drafts: Record<number, PickDraft | null> = {
+      1: makeDraft(101, 1), // locked
+      2: null,
+      3: null,
+      4: null,
+      5: null,
+      6: makeDraft(106, 6) // open
+    };
+
+    const result = buildSubmittablePicks(drafts, MIXED_DEADLINES);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].round_number).toBe(6);
+    expect(result[0].picked_team_id).toBe(6);
+  });
+
+  it('includes all rounds when all deadlines are in the future', () => {
+    const drafts: Record<number, PickDraft | null> = {
+      1: makeDraft(101, 1),
+      2: makeDraft(102, 2),
+      3: null,
+      4: null,
+      5: null,
+      6: makeDraft(106, 6)
+    };
+
+    const result = buildSubmittablePicks(drafts, ALL_OPEN_DEADLINES);
+
+    expect(result).toHaveLength(3);
+    expect(result.map((p) => p.round_number).sort()).toEqual([1, 2, 6]);
+  });
+
+  it('returns empty array when all rounds are locked', () => {
+    const drafts: Record<number, PickDraft | null> = {
+      1: makeDraft(101, 1),
+      2: makeDraft(102, 2),
+      3: null,
+      4: null,
+      5: null,
+      6: null
+    };
+    const allLocked: Record<number, Date> = Object.fromEntries(
+      [1, 2, 3, 4, 5, 6].map((r) => [r, PAST])
+    );
+
+    expect(buildSubmittablePicks(drafts, allLocked)).toHaveLength(0);
+  });
+
+  it('returns empty array when all drafts are null', () => {
+    const drafts: Record<number, PickDraft | null> = {
+      1: null,
+      2: null,
+      3: null,
+      4: null,
+      5: null,
+      6: null
+    };
+
+    expect(buildSubmittablePicks(drafts, ALL_OPEN_DEADLINES)).toHaveLength(0);
+  });
+});
+
+// ── computeHasUnsavedDrafts ───────────────────────────────────────────────────
+
+describe('computeHasUnsavedDrafts', () => {
+  it('returns false when only locked rounds have unsaved drafts', () => {
+    // Round 1 draft differs from saved pick, but deadline has passed
+    const drafts: Record<number, PickDraft | null> = {
+      1: makeDraft(101, 99), // different team from saved pick
+      2: null,
+      3: null,
+      4: null,
+      5: null,
+      6: null
+    };
+    const saved = [makePick(1, 101, 1)];
+
+    expect(computeHasUnsavedDrafts(drafts, saved, MIXED_DEADLINES)).toBe(false);
+  });
+
+  it('returns true when an open round has a draft not yet saved', () => {
+    const drafts: Record<number, PickDraft | null> = {
+      1: makeDraft(101, 99), // locked, differing draft — should be ignored
+      2: null,
+      3: null,
+      4: null,
+      5: null,
+      6: makeDraft(106, 6) // open, no saved pick yet
+    };
+    const saved = [makePick(1, 101, 1)];
+
+    expect(computeHasUnsavedDrafts(drafts, saved, MIXED_DEADLINES)).toBe(true);
+  });
+
+  it('returns true when an open round draft differs from the saved pick', () => {
+    const drafts: Record<number, PickDraft | null> = {
+      1: null,
+      2: null,
+      3: null,
+      4: null,
+      5: null,
+      6: makeDraft(106, 99) // changed from saved team 6
+    };
+    const saved = [makePick(6, 106, 6)];
+
+    expect(computeHasUnsavedDrafts(drafts, saved, MIXED_DEADLINES)).toBe(true);
+  });
+
+  it('returns false when all open round drafts match their saved picks', () => {
+    const drafts: Record<number, PickDraft | null> = {
+      1: null,
+      2: null,
+      3: null,
+      4: null,
+      5: null,
+      6: makeDraft(106, 6)
+    };
+    const saved = [makePick(6, 106, 6)];
+
+    expect(computeHasUnsavedDrafts(drafts, saved, MIXED_DEADLINES)).toBe(false);
+  });
+
+  it('returns false when there are no drafts at all', () => {
+    const drafts: Record<number, PickDraft | null> = {
+      1: null,
+      2: null,
+      3: null,
+      4: null,
+      5: null,
+      6: null
+    };
+
+    expect(computeHasUnsavedDrafts(drafts, [], ALL_OPEN_DEADLINES)).toBe(false);
+  });
+});

--- a/app/(dashboard)/wc-picks-utils.ts
+++ b/app/(dashboard)/wc-picks-utils.ts
@@ -1,10 +1,4 @@
-import { PickDraft, WcPick } from '@/lib/wc-definitions';
-
-type PickInput = {
-  round_number: number;
-  fixture_id: number;
-  picked_team_id: number;
-};
+import { PickDraft, PickInput, WcPick } from '@/lib/wc-definitions';
 
 export function buildSubmittablePicks(
   drafts: Record<number, PickDraft | null>,
@@ -14,7 +8,9 @@ export function buildSubmittablePicks(
   return Object.entries(drafts)
     .filter(([roundStr, draft]) => {
       if (!draft) return false;
-      return now < deadlines[Number(roundStr)];
+      // Mirror the server's boundary (route.ts rejects only when now > deadline),
+      // and keep this consistent with computeHasUnsavedDrafts below.
+      return now <= deadlines[Number(roundStr)];
     })
     .map(([roundStr, draft]) => ({
       round_number: Number(roundStr),

--- a/app/(dashboard)/wc-picks-utils.ts
+++ b/app/(dashboard)/wc-picks-utils.ts
@@ -1,0 +1,43 @@
+import { PickDraft, WcPick } from '@/lib/wc-definitions';
+
+type PickInput = {
+  round_number: number;
+  fixture_id: number;
+  picked_team_id: number;
+};
+
+export function buildSubmittablePicks(
+  drafts: Record<number, PickDraft | null>,
+  deadlines: Record<number, Date>
+): PickInput[] {
+  const now = new Date();
+  return Object.entries(drafts)
+    .filter(([roundStr, draft]) => {
+      if (!draft) return false;
+      return now < deadlines[Number(roundStr)];
+    })
+    .map(([roundStr, draft]) => ({
+      round_number: Number(roundStr),
+      fixture_id: draft!.fixture_id,
+      picked_team_id: draft!.picked_team_id
+    }));
+}
+
+export function computeHasUnsavedDrafts(
+  drafts: Record<number, PickDraft | null>,
+  wcPicks: WcPick[],
+  deadlines: Record<number, Date>
+): boolean {
+  const now = new Date();
+  return Object.entries(drafts).some(([roundStr, draft]) => {
+    if (!draft) return false;
+    const round = Number(roundStr);
+    if (now > deadlines[round]) return false;
+    const existing = wcPicks.find((p) => p.round_number === round);
+    if (!existing) return true;
+    return (
+      existing.picked_team_id !== draft.picked_team_id ||
+      existing.fixture_id !== draft.fixture_id
+    );
+  });
+}

--- a/app/api/wc/picks/route.ts
+++ b/app/api/wc/picks/route.ts
@@ -1,7 +1,7 @@
 import { auth } from '@/lib/auth';
 import { sql } from '@vercel/postgres';
 import { Resend } from 'resend';
-import { WcPick } from '@/lib/wc-definitions';
+import { PickInput, WcPick } from '@/lib/wc-definitions';
 import { WC_ROUND_DEADLINES } from '@/lib/wc-constants';
 
 // ── GET: fetch current user's picks ──────────────────────────────────────────
@@ -48,12 +48,6 @@ export async function GET() {
 
 // ── POST: submit / amend picks (all rounds at once) ───────────────────────────
 
-type PickInput = {
-  round_number: number;
-  fixture_id: number;
-  picked_team_id: number;
-};
-
 export async function POST(request: Request) {
   const session = await auth();
   if (!session?.user?.id) {
@@ -78,17 +72,26 @@ export async function POST(request: Request) {
       [userId]
     );
     if (!leagueResult.rows.length) {
-      return Response.json({ error: 'User is not part of a league' }, { status: 400 });
+      return Response.json(
+        { error: 'User is not part of a league' },
+        { status: 400 }
+      );
     }
     const { league_id } = leagueResult.rows[0];
 
     // Validate round numbers are in range and unique within the submission
     const roundNumbers = picks.map((p) => p.round_number);
     if (roundNumbers.some((r) => r < 1 || r > 6)) {
-      return Response.json({ error: 'Round number must be between 1 and 6' }, { status: 400 });
+      return Response.json(
+        { error: 'Round number must be between 1 and 6' },
+        { status: 400 }
+      );
     }
     if (new Set(roundNumbers).size !== roundNumbers.length) {
-      return Response.json({ error: 'Duplicate round numbers in submission' }, { status: 400 });
+      return Response.json(
+        { error: 'Duplicate round numbers in submission' },
+        { status: 400 }
+      );
     }
 
     // Check deadlines — reject any pick for a locked round
@@ -104,7 +107,11 @@ export async function POST(request: Request) {
 
     // Validate each fixture_id exists, belongs to the correct round, and picked_team_id is a participant
     for (const pick of picks) {
-      const { rows } = await sql.query<{ home_team_id: number; away_team_id: number; round_number: number }>(
+      const { rows } = await sql.query<{
+        home_team_id: number;
+        away_team_id: number;
+        round_number: number;
+      }>(
         `SELECT home_team_id, away_team_id, round_number FROM wc_fixtures WHERE id = $1`,
         [pick.fixture_id]
       );
@@ -114,16 +121,27 @@ export async function POST(request: Request) {
           { status: 400 }
         );
       }
-      const { home_team_id, away_team_id, round_number: fixtureRound } = rows[0];
+      const {
+        home_team_id,
+        away_team_id,
+        round_number: fixtureRound
+      } = rows[0];
       if (fixtureRound !== pick.round_number) {
         return Response.json(
-          { error: `Fixture ${pick.fixture_id} does not belong to Round ${pick.round_number}` },
+          {
+            error: `Fixture ${pick.fixture_id} does not belong to Round ${pick.round_number}`
+          },
           { status: 400 }
         );
       }
-      if (pick.picked_team_id !== home_team_id && pick.picked_team_id !== away_team_id) {
+      if (
+        pick.picked_team_id !== home_team_id &&
+        pick.picked_team_id !== away_team_id
+      ) {
         return Response.json(
-          { error: `Team ${pick.picked_team_id} does not play in fixture ${pick.fixture_id}` },
+          {
+            error: `Team ${pick.picked_team_id} does not play in fixture ${pick.fixture_id}`
+          },
           { status: 400 }
         );
       }
@@ -140,7 +158,10 @@ export async function POST(request: Request) {
 
     // Also check against existing picks for rounds NOT being replaced
     const replacedRounds = new Set(roundNumbers);
-    const { rows: existingPicks } = await sql.query<{ round_number: number; picked_team_id: number }>(
+    const { rows: existingPicks } = await sql.query<{
+      round_number: number;
+      picked_team_id: number;
+    }>(
       `SELECT round_number, picked_team_id FROM wc_picks
        WHERE user_id = $1 AND league_id = $2`,
       [userId, league_id]
@@ -149,7 +170,9 @@ export async function POST(request: Request) {
       if (!replacedRounds.has(existing.round_number)) {
         if (submittedTeamIds.includes(existing.picked_team_id)) {
           return Response.json(
-            { error: `That team is already picked in Round ${existing.round_number}` },
+            {
+              error: `That team is already picked in Round ${existing.round_number}`
+            },
             { status: 400 }
           );
         }
@@ -168,7 +191,13 @@ export async function POST(request: Request) {
            picked_team_id = EXCLUDED.picked_team_id,
            last_amended_at = NOW()
          WHERE wc_picks.is_correct IS NULL`,
-        [userId, league_id, pick.round_number, pick.fixture_id, pick.picked_team_id]
+        [
+          userId,
+          league_id,
+          pick.round_number,
+          pick.fixture_id,
+          pick.picked_team_id
+        ]
       );
       savedCount += result.rowCount ?? 0;
     }
@@ -178,15 +207,22 @@ export async function POST(request: Request) {
       try {
         // Fetch team names for the email summary
         const teamIds = [...new Set(picks.map((p) => p.picked_team_id))];
-        const { rows: teamRows } = await sql.query<{ id: number; name: string }>(
-          `SELECT id, name FROM wc_teams WHERE id = ANY($1::int[])`,
-          [teamIds]
+        const { rows: teamRows } = await sql.query<{
+          id: number;
+          name: string;
+        }>(`SELECT id, name FROM wc_teams WHERE id = ANY($1::int[])`, [
+          teamIds
+        ]);
+        const teamNameById = Object.fromEntries(
+          teamRows.map((t) => [t.id, t.name])
         );
-        const teamNameById = Object.fromEntries(teamRows.map((t) => [t.id, t.name]));
 
         const pickLines = picks
           .sort((a, b) => a.round_number - b.round_number)
-          .map((p) => `<li><strong>Round ${p.round_number}:</strong> ${teamNameById[p.picked_team_id]}</li>`)
+          .map(
+            (p) =>
+              `<li><strong>Round ${p.round_number}:</strong> ${teamNameById[p.picked_team_id]}</li>`
+          )
           .join('');
 
         const adminEmail = process.env.NEXT_PUBLIC_MY_EMAIL_ADDRESS;
@@ -206,7 +242,10 @@ export async function POST(request: Request) {
         });
       } catch (emailError) {
         // Don't fail the request if email sending fails
-        console.error('Failed to send WC picks confirmation email:', emailError);
+        console.error(
+          'Failed to send WC picks confirmation email:',
+          emailError
+        );
       }
     }
 

--- a/lib/wc-definitions.ts
+++ b/lib/wc-definitions.ts
@@ -38,6 +38,13 @@ export type PickDraft = {
   picked_team_id: number;
 };
 
+// A single pick as submitted to POST /api/wc/picks
+export type PickInput = {
+  round_number: number;
+  fixture_id: number;
+  picked_team_id: number;
+};
+
 // Response from PATCH /api/wc/admin after recording a fixture result
 export type WcAdminResultResponse = {
   success: boolean;


### PR DESCRIPTION
## Summary

- Users changing a Round 6 pick were seeing \"Deadline has passed for Round 1\" because the form submitted all non-null drafts (including locked rounds) in a single batch, and the API rejected the whole thing on the first expired round
- Fixes the submit payload to filter out rounds past their deadline before the API call
- Fixes `hasUnsavedDrafts` to exclude locked rounds, so the Save button and unsaved-changes banner only reflect rounds still open for editing
- Extracted the two logic blocks into `wc-picks-utils.ts` with 10 unit tests covering the regression scenarios and a deadline-boundary case
- Moved `PickInput` type into `wc-definitions.ts` to eliminate duplication between the utility and the API route

## Test plan

- [ ] Run `npm run test:run` — 21 tests, all passing
- [ ] Run `tsc` to verify no type errors
- [ ] Sign in as a user and change a Round 6 pick — save should succeed without any \"Deadline has passed\" error
- [ ] Verify locked rounds (1–5) do not appear in the POST payload (Network tab)
- [ ] Confirm the Save button is disabled when only locked-round drafts differ from saved picks

🤖 Generated with [Claude Code](https://claude.com/claude-code)