### PR TITLE
World Cup 2026 knockout stage + parallel game

### DIFF
--- a/app/(dashboard)/admin/knockout/knockout-admin-form.tsx
+++ b/app/(dashboard)/admin/knockout/knockout-admin-form.tsx
@@ -1,0 +1,367 @@
+'use client';
+
+import { useState } from 'react';
+import { Select } from '@/components/ui/select';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { WcKnockoutFixture } from '@/lib/wc-definitions';
+import { WC_TEAMS, WC_ROUND_FIXTURE_LABELS } from '@/lib/wc-constants';
+
+// Dropdown options as "flag name"; map back to the bare name (or null) for the API.
+const TBD = 'TBD';
+const TEAM_OPTIONS = [TBD, ...WC_TEAMS.map((t) => `${t.flag} ${t.name}`)];
+const nameByOption: Record<string, string | null> = {
+  [TBD]: null,
+  ...Object.fromEntries(WC_TEAMS.map((t) => [`${t.flag} ${t.name}`, t.name]))
+};
+const optionByName: Record<string, string> = Object.fromEntries(
+  WC_TEAMS.map((t) => [t.name, `${t.flag} ${t.name}`])
+);
+
+function optionFor(name: string | null): string {
+  return name ? (optionByName[name] ?? TBD) : TBD;
+}
+
+function formatBST(iso: string): string {
+  return new Date(iso).toLocaleString('en-GB', {
+    timeZone: 'Europe/London',
+    weekday: 'short',
+    day: 'numeric',
+    month: 'short',
+    hour: '2-digit',
+    minute: '2-digit'
+  });
+}
+
+function isValidScore(v: string): boolean {
+  return /^\d+$/.test(v.trim()) && Number(v) <= 99;
+}
+
+type TeamDraft = { home: string; away: string };
+type ScoreDraft = { home: string; away: string };
+type Feedback = { type: 'success' | 'error'; msg: string };
+
+export default function KnockoutAdminForm({
+  fixtures: initialFixtures
+}: {
+  fixtures: WcKnockoutFixture[];
+}) {
+  const [fixtures, setFixtures] = useState(initialFixtures);
+
+  const [teamDrafts, setTeamDrafts] = useState<Record<number, TeamDraft>>(() =>
+    Object.fromEntries(
+      initialFixtures.map((f) => [
+        f.id,
+        { home: optionFor(f.home_team_name), away: optionFor(f.away_team_name) }
+      ])
+    )
+  );
+  const [scoreDrafts, setScoreDrafts] = useState<Record<number, ScoreDraft>>(
+    () =>
+      Object.fromEntries(
+        initialFixtures.map((f) => [
+          f.id,
+          {
+            home: f.home_team_score?.toString() ?? '',
+            away: f.away_team_score?.toString() ?? ''
+          }
+        ])
+      )
+  );
+
+  const [savingTeams, setSavingTeams] = useState<Set<number>>(new Set());
+  const [savingResult, setSavingResult] = useState<Set<number>>(new Set());
+  const [feedback, setFeedback] = useState<Record<number, Feedback>>({});
+
+  function setFb(id: number, fb: Feedback) {
+    setFeedback((prev) => ({ ...prev, [id]: fb }));
+  }
+  function clearFb(id: number) {
+    setFeedback((prev) => {
+      if (!prev[id]) return prev;
+      const next = { ...prev };
+      delete next[id];
+      return next;
+    });
+  }
+  function toggleSaving(
+    set: React.Dispatch<React.SetStateAction<Set<number>>>,
+    id: number,
+    on: boolean
+  ) {
+    set((prev) => {
+      const next = new Set(prev);
+      if (on) next.add(id);
+      else next.delete(id);
+      return next;
+    });
+  }
+
+  async function patchFixture(id: number, payload: Record<string, unknown>) {
+    const res = await fetch('/api/wc/knockout/fixtures', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ fixture_id: id, ...payload })
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || 'Failed to save.');
+    return data as WcKnockoutFixture;
+  }
+
+  async function saveTeams(f: WcKnockoutFixture) {
+    const draft = teamDrafts[f.id];
+    toggleSaving(setSavingTeams, f.id, true);
+    clearFb(f.id);
+    try {
+      const updated = await patchFixture(f.id, {
+        home_team_name: nameByOption[draft.home],
+        away_team_name: nameByOption[draft.away]
+      });
+      setFixtures((prev) => prev.map((x) => (x.id === f.id ? updated : x)));
+      setFb(f.id, { type: 'success', msg: 'Teams saved.' });
+    } catch (e) {
+      setFb(f.id, {
+        type: 'error',
+        msg: e instanceof Error ? e.message : 'Failed to save.'
+      });
+    } finally {
+      toggleSaving(setSavingTeams, f.id, false);
+    }
+  }
+
+  async function setPredicted(f: WcKnockoutFixture) {
+    toggleSaving(setSavingTeams, f.id, true);
+    clearFb(f.id);
+    try {
+      await patchFixture(f.id, { is_predicted: true });
+      // Reflect locally: this one predicted, others in the round cleared.
+      setFixtures((prev) =>
+        prev.map((x) =>
+          x.round_number === f.round_number
+            ? { ...x, is_predicted: x.id === f.id }
+            : x
+        )
+      );
+      setFb(f.id, { type: 'success', msg: 'Set as the predicted match.' });
+    } catch (e) {
+      setFb(f.id, {
+        type: 'error',
+        msg: e instanceof Error ? e.message : 'Failed to save.'
+      });
+    } finally {
+      toggleSaving(setSavingTeams, f.id, false);
+    }
+  }
+
+  async function saveResult(f: WcKnockoutFixture) {
+    const draft = scoreDrafts[f.id];
+    if (!isValidScore(draft.home) || !isValidScore(draft.away)) {
+      setFb(f.id, { type: 'error', msg: 'Enter both scores (0–99).' });
+      return;
+    }
+    toggleSaving(setSavingResult, f.id, true);
+    clearFb(f.id);
+    try {
+      const res = await fetch('/api/wc/knockout/admin', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          fixture_id: f.id,
+          home_team_score: Number(draft.home),
+          away_team_score: Number(draft.away)
+        })
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Failed to save result.');
+      setFixtures((prev) =>
+        prev.map((x) =>
+          x.id === f.id
+            ? {
+                ...x,
+                home_team_score: Number(draft.home),
+                away_team_score: Number(draft.away),
+                is_complete: true
+              }
+            : x
+        )
+      );
+      setFb(f.id, {
+        type: 'success',
+        msg: `Result saved · ${data.picks_scored} prediction${data.picks_scored === 1 ? '' : 's'} scored.`
+      });
+    } catch (e) {
+      setFb(f.id, {
+        type: 'error',
+        msg: e instanceof Error ? e.message : 'Failed to save result.'
+      });
+    } finally {
+      toggleSaving(setSavingResult, f.id, false);
+    }
+  }
+
+  const rounds = [...new Set(fixtures.map((f) => f.round_number))].sort(
+    (a, b) => a - b
+  );
+
+  return (
+    <main className="my-6 flex flex-col gap-6">
+      <div>
+        <h1 className="text-2xl font-bold">Knockout admin</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Set the teams as the bracket resolves, and enter results to score
+          predictions. Each round&apos;s predicted match is what players
+          predict.
+        </p>
+      </div>
+
+      {rounds.map((round) => (
+        <section key={round} className="flex flex-col gap-3">
+          <h2 className="text-sm font-bold uppercase tracking-wide text-gray-500">
+            {WC_ROUND_FIXTURE_LABELS[round]}
+          </h2>
+
+          {fixtures
+            .filter((f) => f.round_number === round)
+            .map((f) => {
+              const team = teamDrafts[f.id];
+              const score = scoreDrafts[f.id];
+              const fb = feedback[f.id];
+              return (
+                <Card key={f.id} className="rounded-xl bg-white shadow-sm">
+                  <CardContent className="p-4 flex flex-col gap-3">
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="text-xs font-semibold text-gray-700">
+                        {f.match_label}
+                      </span>
+                      {f.is_predicted ? (
+                        <span className="text-xs font-semibold text-green-600 whitespace-nowrap">
+                          ★ Predicted
+                        </span>
+                      ) : (
+                        <button
+                          onClick={() => setPredicted(f)}
+                          disabled={savingTeams.has(f.id)}
+                          className="text-xs text-amber-700 underline whitespace-nowrap disabled:opacity-50"
+                        >
+                          Set predicted
+                        </button>
+                      )}
+                    </div>
+
+                    <div className="text-xs text-gray-500">
+                      Kicks off {formatBST(f.kickoff_time)}
+                    </div>
+
+                    {/* Teams */}
+                    <div className="flex flex-col gap-2">
+                      <label className="flex items-center gap-2 text-sm">
+                        <span className="w-12 text-gray-500">Home</span>
+                        <Select
+                          className="flex-1"
+                          options={TEAM_OPTIONS}
+                          value={team.home}
+                          onChange={(e) => {
+                            const v = e.target.value;
+                            setTeamDrafts((prev) => ({
+                              ...prev,
+                              [f.id]: { ...prev[f.id], home: v }
+                            }));
+                            clearFb(f.id);
+                          }}
+                        />
+                      </label>
+                      <label className="flex items-center gap-2 text-sm">
+                        <span className="w-12 text-gray-500">Away</span>
+                        <Select
+                          className="flex-1"
+                          options={TEAM_OPTIONS}
+                          value={team.away}
+                          onChange={(e) => {
+                            const v = e.target.value;
+                            setTeamDrafts((prev) => ({
+                              ...prev,
+                              [f.id]: { ...prev[f.id], away: v }
+                            }));
+                            clearFb(f.id);
+                          }}
+                        />
+                      </label>
+                      <Button
+                        variant="outline"
+                        onClick={() => saveTeams(f)}
+                        disabled={savingTeams.has(f.id)}
+                        className="self-start"
+                      >
+                        {savingTeams.has(f.id) ? 'Saving…' : 'Save teams'}
+                      </Button>
+                    </div>
+
+                    {/* Result */}
+                    <div className="flex items-center gap-2 border-t border-gray-100 pt-3">
+                      <span className="text-sm text-gray-500">Result</span>
+                      <Input
+                        type="text"
+                        inputMode="numeric"
+                        maxLength={2}
+                        aria-label="Home score"
+                        value={score.home}
+                        onChange={(e) => {
+                          const v = e.target.value.replace(/[^\d]/g, '');
+                          setScoreDrafts((prev) => ({
+                            ...prev,
+                            [f.id]: { ...prev[f.id], home: v }
+                          }));
+                          clearFb(f.id);
+                        }}
+                        className="h-10 w-12 text-center text-base"
+                      />
+                      <span className="text-gray-400">–</span>
+                      <Input
+                        type="text"
+                        inputMode="numeric"
+                        maxLength={2}
+                        aria-label="Away score"
+                        value={score.away}
+                        onChange={(e) => {
+                          const v = e.target.value.replace(/[^\d]/g, '');
+                          setScoreDrafts((prev) => ({
+                            ...prev,
+                            [f.id]: { ...prev[f.id], away: v }
+                          }));
+                          clearFb(f.id);
+                        }}
+                        className="h-10 w-12 text-center text-base"
+                      />
+                      <Button
+                        onClick={() => saveResult(f)}
+                        disabled={savingResult.has(f.id)}
+                      >
+                        {savingResult.has(f.id)
+                          ? 'Saving…'
+                          : f.is_complete
+                            ? 'Update'
+                            : 'Save'}
+                      </Button>
+                    </div>
+
+                    {fb && (
+                      <p
+                        className={`text-xs ${
+                          fb.type === 'success'
+                            ? 'text-green-600'
+                            : 'text-red-600'
+                        }`}
+                      >
+                        {fb.msg}
+                      </p>
+                    )}
+                  </CardContent>
+                </Card>
+              );
+            })}
+        </section>
+      ))}
+    </main>
+  );
+}

--- a/app/(dashboard)/admin/knockout/page.tsx
+++ b/app/(dashboard)/admin/knockout/page.tsx
@@ -1,0 +1,40 @@
+import { redirect } from 'next/navigation';
+import { sql } from '@vercel/postgres';
+import { auth } from '@/lib/auth';
+import { isAdminEmail } from '@/lib/admin';
+import { WcKnockoutFixture } from '@/lib/wc-definitions';
+import KnockoutAdminForm from './knockout-admin-form';
+
+// Hidden admin page for editing knockout fixture teams and entering results.
+// Not linked from the nav; non-admins are redirected home. Fixtures are fetched
+// with direct SQL (not the cached /api/wc/knockout/fixtures route) so recent
+// edits are always reflected.
+export default async function KnockoutAdminPage() {
+  const session = await auth();
+  if (!isAdminEmail(session?.user?.email)) {
+    redirect('/');
+  }
+
+  const { rows } = await sql.query<WcKnockoutFixture>(
+    `SELECT
+      id,
+      round_number,
+      match_label,
+      home_team_name,
+      away_team_name,
+      kickoff_time,
+      is_predicted,
+      home_team_score,
+      away_team_score,
+      is_complete
+    FROM wc_knockout_fixtures
+    ORDER BY round_number, kickoff_time`
+  );
+
+  const fixtures = rows.map((f) => ({
+    ...f,
+    kickoff_time: new Date(f.kickoff_time).toISOString()
+  }));
+
+  return <KnockoutAdminForm fixtures={fixtures} />;
+}

--- a/app/(dashboard)/game-selector.tsx
+++ b/app/(dashboard)/game-selector.tsx
@@ -1,0 +1,39 @@
+import { Select } from '@/components/ui/select';
+import { WcLeagueMembership } from '@/lib/wc-definitions';
+
+// Lets a user who belongs to more than one WC game choose which one they're
+// viewing. Hidden when there's nothing to switch between.
+export default function GameSelector({
+  leagues,
+  selectedLeagueId,
+  onSelect
+}: {
+  leagues: WcLeagueMembership[];
+  selectedLeagueId: number | null;
+  onSelect: (leagueId: number) => void;
+}) {
+  if (leagues.length < 2) return null;
+
+  const selected = leagues.find((l) => l.league_id === selectedLeagueId);
+
+  return (
+    <div className="flex items-center justify-center gap-2 mt-3">
+      <label
+        htmlFor="game-select"
+        className="text-sm font-medium text-gray-700"
+      >
+        Game:
+      </label>
+      <Select
+        id="game-select"
+        className="w-auto bg-white"
+        options={leagues.map((l) => l.name)}
+        value={selected?.name ?? ''}
+        onChange={(e) => {
+          const league = leagues.find((l) => l.name === e.target.value);
+          if (league) onSelect(league.league_id);
+        }}
+      />
+    </div>
+  );
+}

--- a/app/(dashboard)/knockout-picks-form.tsx
+++ b/app/(dashboard)/knockout-picks-form.tsx
@@ -260,7 +260,7 @@ export default function KnockoutPicksForm({
 
               <div className="flex items-center justify-center gap-2 text-sm font-medium">
                 <span className="flex-1 text-right">
-                  {flagFor(f.home_team_name)} {f.home_team_name ?? 'TBD'}
+                  {f.home_team_name ?? 'TBD'} {flagFor(f.home_team_name)}
                 </span>
                 {editable ? (
                   <ScoreInput
@@ -288,7 +288,7 @@ export default function KnockoutPicksForm({
                   </span>
                 )}
                 <span className="flex-1 text-left">
-                  {f.away_team_name ?? 'TBD'} {flagFor(f.away_team_name)}
+                  {flagFor(f.away_team_name)} {f.away_team_name ?? 'TBD'}
                 </span>
               </div>
 

--- a/app/(dashboard)/knockout-picks-form.tsx
+++ b/app/(dashboard)/knockout-picks-form.tsx
@@ -208,6 +208,25 @@ export default function KnockoutPicksForm({
       pickByRound.get(f.round_number)?.points == null
   );
 
+  // Enable Save only when an open round has valid scores that differ from what's
+  // already saved (a new or changed prediction).
+  const hasSomethingToSave =
+    canPlay &&
+    predicted.some((f) => {
+      if (now > getKnockoutDeadline(f.kickoff_time)) return false;
+      const pick = pickByRound.get(f.round_number);
+      if (pick?.points != null) return false; // already scored
+      const draft = drafts[f.round_number];
+      if (!draft || !isValidScore(draft.home) || !isValidScore(draft.away)) {
+        return false;
+      }
+      return (
+        !pick ||
+        Number(draft.home) !== pick.home_score ||
+        Number(draft.away) !== pick.away_score
+      );
+    });
+
   return (
     <div className="flex flex-col gap-4">
       {!isAuthenticated && (
@@ -227,6 +246,26 @@ export default function KnockoutPicksForm({
             not submit predictions.
           </CardContent>
         </Card>
+      )}
+
+      {canPlay && hasOpenRound && (
+        <Button
+          onClick={save}
+          disabled={submitting || !hasSomethingToSave}
+          className="w-full"
+        >
+          {submitting ? 'Saving…' : 'Save predictions'}
+        </Button>
+      )}
+
+      {feedback && (
+        <p
+          className={`text-sm text-center ${
+            feedback.type === 'success' ? 'text-green-600' : 'text-red-600'
+          }`}
+        >
+          {feedback.msg}
+        </p>
       )}
 
       {predicted.map((f) => {
@@ -318,21 +357,6 @@ export default function KnockoutPicksForm({
         );
       })}
 
-      {feedback && (
-        <p
-          className={`text-sm text-center ${
-            feedback.type === 'success' ? 'text-green-600' : 'text-red-600'
-          }`}
-        >
-          {feedback.msg}
-        </p>
-      )}
-
-      {canPlay && hasOpenRound && (
-        <Button onClick={save} disabled={submitting} className="w-full">
-          {submitting ? 'Saving…' : 'Save predictions'}
-        </Button>
-      )}
     </div>
   );
 }

--- a/app/(dashboard)/knockout-picks-form.tsx
+++ b/app/(dashboard)/knockout-picks-form.tsx
@@ -1,0 +1,330 @@
+import { useEffect, useState, Dispatch, SetStateAction } from 'react';
+import { useSession } from 'next-auth/react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  WcKnockoutFixture,
+  WcKnockoutPick,
+  KnockoutPickInput
+} from '@/lib/wc-definitions';
+import {
+  WC_ROUND_FIXTURE_LABELS,
+  WC_TEAM_FLAGS,
+  getKnockoutDeadline
+} from '@/lib/wc-constants';
+
+// Local editing state — scores are strings so inputs can be empty mid-type.
+type Draft = { home: string; away: string };
+
+function flagFor(name: string | null): string {
+  return (name && WC_TEAM_FLAGS[name]) || '🏳';
+}
+
+function formatBST(date: Date): string {
+  return date.toLocaleString('en-GB', {
+    timeZone: 'Europe/London',
+    weekday: 'short',
+    day: 'numeric',
+    month: 'short',
+    hour: '2-digit',
+    minute: '2-digit'
+  });
+}
+
+function isValidScore(v: string): boolean {
+  return /^\d+$/.test(v.trim()) && Number(v) <= 99;
+}
+
+function initDrafts(
+  fixtures: WcKnockoutFixture[],
+  pickByRound: Map<number, WcKnockoutPick>
+): Record<number, Draft> {
+  const drafts: Record<number, Draft> = {};
+  for (const f of fixtures) {
+    const pick = pickByRound.get(f.round_number);
+    drafts[f.round_number] = {
+      home: pick ? String(pick.home_score) : '',
+      away: pick ? String(pick.away_score) : ''
+    };
+  }
+  return drafts;
+}
+
+function ScoreInput({
+  value,
+  onChange,
+  disabled,
+  label
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  disabled: boolean;
+  label: string;
+}) {
+  return (
+    <Input
+      type="text"
+      inputMode="numeric"
+      pattern="[0-9]*"
+      maxLength={2}
+      aria-label={label}
+      value={value}
+      disabled={disabled}
+      onChange={(e) => onChange(e.target.value.replace(/[^\d]/g, ''))}
+      className="h-10 w-12 text-center text-base"
+    />
+  );
+}
+
+export default function KnockoutPicksForm({
+  leagueId,
+  eligible,
+  fixtures,
+  isLoadingFixtures,
+  picks,
+  isLoadingPicks,
+  setRefreshTrigger
+}: {
+  leagueId: number | null;
+  eligible: boolean;
+  fixtures: WcKnockoutFixture[];
+  isLoadingFixtures: boolean;
+  picks: WcKnockoutPick[];
+  isLoadingPicks: boolean;
+  setRefreshTrigger: Dispatch<SetStateAction<number>>;
+}) {
+  const { status } = useSession();
+  const isAuthenticated = status === 'authenticated';
+
+  const predicted = fixtures
+    .filter((f) => f.is_predicted)
+    .sort((a, b) => a.round_number - b.round_number);
+
+  const pickByRound = new Map(picks.map((p) => [p.round_number, p]));
+
+  const [drafts, setDrafts] = useState<Record<number, Draft>>({});
+  const [submitting, setSubmitting] = useState(false);
+  const [feedback, setFeedback] = useState<{
+    type: 'success' | 'error';
+    msg: string;
+  } | null>(null);
+
+  // Re-seed drafts from saved picks whenever the league/picks/fixtures change.
+  useEffect(() => {
+    setDrafts(initDrafts(predicted, pickByRound));
+    setFeedback(null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [leagueId, isLoadingPicks, isLoadingFixtures]);
+
+  if (isLoadingFixtures || (isAuthenticated && isLoadingPicks)) {
+    return (
+      <Card className="rounded-xl bg-white shadow-sm">
+        <CardContent className="p-8 text-center text-sm text-muted-foreground">
+          Loading…
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const now = new Date();
+
+  function setScore(round: number, side: 'home' | 'away', value: string) {
+    setDrafts((prev) => ({
+      ...prev,
+      [round]: { ...(prev[round] ?? { home: '', away: '' }), [side]: value }
+    }));
+    setFeedback(null);
+  }
+
+  async function save() {
+    const toSubmit: KnockoutPickInput[] = [];
+    for (const f of predicted) {
+      const draft = drafts[f.round_number];
+      const locked = now > getKnockoutDeadline(f.kickoff_time);
+      const scored = pickByRound.get(f.round_number)?.points != null;
+      if (!draft || locked || scored) continue;
+
+      const hasHome = draft.home.trim() !== '';
+      const hasAway = draft.away.trim() !== '';
+      if (!hasHome && !hasAway) continue; // untouched round
+
+      if (!isValidScore(draft.home) || !isValidScore(draft.away)) {
+        setFeedback({
+          type: 'error',
+          msg: `Enter both scores (0–99) for ${WC_ROUND_FIXTURE_LABELS[f.round_number]}.`
+        });
+        return;
+      }
+      toSubmit.push({
+        round_number: f.round_number,
+        fixture_id: f.id,
+        home_score: Number(draft.home),
+        away_score: Number(draft.away)
+      });
+    }
+
+    if (toSubmit.length === 0) {
+      setFeedback({ type: 'error', msg: 'No open predictions to save.' });
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const res = await fetch('/api/wc/knockout/picks', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ league_id: leagueId, picks: toSubmit })
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setFeedback({ type: 'error', msg: data.error || 'Failed to save.' });
+        return;
+      }
+      setFeedback({
+        type: 'success',
+        msg: `Saved ${toSubmit.length} prediction${toSubmit.length === 1 ? '' : 's'} — confirmation emailed.`
+      });
+      setRefreshTrigger((n) => n + 1);
+    } catch {
+      setFeedback({ type: 'error', msg: 'Network error — try again.' });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const canPlay = isAuthenticated && eligible;
+  const hasOpenRound = predicted.some(
+    (f) =>
+      now <= getKnockoutDeadline(f.kickoff_time) &&
+      pickByRound.get(f.round_number)?.points == null
+  );
+
+  return (
+    <div className="flex flex-col gap-4">
+      {!isAuthenticated && (
+        <Card className="rounded-xl bg-amber-50 border border-amber-200 shadow-sm">
+          <CardContent className="p-4 text-sm text-amber-800 text-center">
+            <a href="/api/auth/signin" className="font-semibold underline">
+              Sign in
+            </a>{' '}
+            to submit your knockout predictions.
+          </CardContent>
+        </Card>
+      )}
+      {isAuthenticated && !eligible && (
+        <Card className="rounded-xl bg-gray-50 border border-gray-200 shadow-sm">
+          <CardContent className="p-4 text-sm text-gray-600 text-center">
+            You&apos;re a spectator in this game — you can follow the scores but
+            not submit predictions.
+          </CardContent>
+        </Card>
+      )}
+
+      {predicted.map((f) => {
+        const round = f.round_number;
+        const pick = pickByRound.get(round);
+        const deadline = getKnockoutDeadline(f.kickoff_time);
+        const locked = now > deadline;
+        const scored = pick?.points != null;
+        const editable = canPlay && !locked && !scored;
+        const draft = drafts[round] ?? { home: '', away: '' };
+
+        const statusBadge = scored
+          ? `${pick!.points} pt${pick!.points === 1 ? '' : 's'}`
+          : locked
+            ? 'Locked'
+            : pick
+              ? 'Saved'
+              : 'Open';
+
+        return (
+          <Card key={f.id} className="rounded-xl bg-white shadow-sm">
+            <CardContent className="p-4 flex flex-col gap-3">
+              <div className="flex items-center justify-between">
+                <span className="text-xs font-bold uppercase tracking-wide text-gray-500">
+                  {WC_ROUND_FIXTURE_LABELS[round]}
+                </span>
+                <span
+                  className={`text-xs font-semibold ${
+                    scored
+                      ? 'text-green-600'
+                      : locked
+                        ? 'text-gray-400'
+                        : 'text-amber-600'
+                  }`}
+                >
+                  {statusBadge}
+                </span>
+              </div>
+
+              <div className="flex items-center justify-center gap-2 text-sm font-medium">
+                <span className="flex-1 text-right">
+                  {flagFor(f.home_team_name)} {f.home_team_name ?? 'TBD'}
+                </span>
+                {editable ? (
+                  <ScoreInput
+                    value={draft.home}
+                    onChange={(v) => setScore(round, 'home', v)}
+                    disabled={submitting}
+                    label={`${f.home_team_name ?? 'Home'} score`}
+                  />
+                ) : (
+                  <span className="w-12 text-center text-base font-semibold">
+                    {pick ? pick.home_score : '–'}
+                  </span>
+                )}
+                <span className="text-gray-400">–</span>
+                {editable ? (
+                  <ScoreInput
+                    value={draft.away}
+                    onChange={(v) => setScore(round, 'away', v)}
+                    disabled={submitting}
+                    label={`${f.away_team_name ?? 'Away'} score`}
+                  />
+                ) : (
+                  <span className="w-12 text-center text-base font-semibold">
+                    {pick ? pick.away_score : '–'}
+                  </span>
+                )}
+                <span className="flex-1 text-left">
+                  {f.away_team_name ?? 'TBD'} {flagFor(f.away_team_name)}
+                </span>
+              </div>
+
+              <div className="text-center text-xs text-gray-500">
+                Kicks off {formatBST(new Date(f.kickoff_time))} · deadline{' '}
+                {formatBST(deadline)}
+              </div>
+
+              {scored && f.is_complete && (
+                <div className="text-center text-xs text-gray-600">
+                  Result:{' '}
+                  <span className="font-semibold">
+                    {f.home_team_score}–{f.away_team_score}
+                  </span>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        );
+      })}
+
+      {feedback && (
+        <p
+          className={`text-sm text-center ${
+            feedback.type === 'success' ? 'text-green-600' : 'text-red-600'
+          }`}
+        >
+          {feedback.msg}
+        </p>
+      )}
+
+      {canPlay && hasOpenRound && (
+        <Button onClick={save} disabled={submitting} className="w-full">
+          {submitting ? 'Saving…' : 'Save predictions'}
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/app/(dashboard)/knockout-picks-form.tsx
+++ b/app/(dashboard)/knockout-picks-form.tsx
@@ -181,9 +181,17 @@ export default function KnockoutPicksForm({
         setFeedback({ type: 'error', msg: data.error || 'Failed to save.' });
         return;
       }
+      const saved: number = data.savedCount ?? toSubmit.length;
+      if (saved === 0) {
+        setFeedback({
+          type: 'error',
+          msg: 'No open predictions were saved.'
+        });
+        return;
+      }
       setFeedback({
         type: 'success',
-        msg: `Saved ${toSubmit.length} prediction${toSubmit.length === 1 ? '' : 's'} — confirmation emailed.`
+        msg: `Saved ${saved} prediction${saved === 1 ? '' : 's'} — confirmation emailed.`
       });
       setRefreshTrigger((n) => n + 1);
     } catch {

--- a/app/(dashboard)/knockout-standings.tsx
+++ b/app/(dashboard)/knockout-standings.tsx
@@ -1,0 +1,73 @@
+import { useSession } from 'next-auth/react';
+import { Card, CardContent } from '@/components/ui/card';
+import { WcKnockoutStanding } from '@/lib/wc-definitions';
+
+export default function KnockoutStandings({
+  standings,
+  isLoading
+}: {
+  standings: WcKnockoutStanding[];
+  isLoading: boolean;
+}) {
+  const { data: session } = useSession();
+  const myId = session?.user?.id;
+
+  return (
+    <Card className="rounded-xl bg-white shadow-sm">
+      <CardContent className="p-4">
+        <h3 className="text-sm font-bold uppercase tracking-wide text-gray-500 mb-3">
+          Standings
+        </h3>
+
+        {isLoading ? (
+          <p className="text-sm text-muted-foreground text-center py-4">
+            Loading…
+          </p>
+        ) : standings.length === 0 ? (
+          <p className="text-sm text-muted-foreground text-center py-4">
+            No predictions yet.
+          </p>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-gray-200 text-xs uppercase tracking-wide text-gray-500">
+                <th className="text-left py-2 w-10">#</th>
+                <th className="text-left py-2">Player</th>
+                <th className="text-right py-2 w-16">Pts</th>
+              </tr>
+            </thead>
+            <tbody>
+              {standings.map((s, i) => {
+                // Ties share a position.
+                const position =
+                  i > 0 && standings[i - 1].points === s.points ? null : i + 1;
+                const isMe = myId != null && String(s.user_id) === myId;
+                return (
+                  <tr
+                    key={s.user_id}
+                    className={`border-b border-gray-100 last:border-0 ${
+                      isMe ? 'bg-amber-50 font-semibold' : ''
+                    }`}
+                  >
+                    <td className="py-2 text-gray-500">{position ?? ''}</td>
+                    <td className="py-2 text-gray-800">
+                      {s.user_name ?? 'Unknown'}
+                      {isMe && (
+                        <span className="ml-1 text-xs text-amber-600">
+                          (you)
+                        </span>
+                      )}
+                    </td>
+                    <td className="py-2 text-right font-semibold text-gray-900">
+                      {s.points}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/(dashboard)/knockout-standings.tsx
+++ b/app/(dashboard)/knockout-standings.tsx
@@ -1,23 +1,39 @@
 import { useSession } from 'next-auth/react';
 import { Card, CardContent } from '@/components/ui/card';
 import { WcKnockoutStanding } from '@/lib/wc-definitions';
+import { WC_LEAGUES } from '@/lib/wc-constants';
 
 export default function KnockoutStandings({
   standings,
-  isLoading
+  isLoading,
+  leagueId
 }: {
   standings: WcKnockoutStanding[];
   isLoading: boolean;
+  leagueId: number | null;
 }) {
   const { data: session } = useSession();
   const myId = session?.user?.id;
 
+  // Fixed pot if the game has one configured (e.g. Game 1's group-stage pool),
+  // otherwise £10 per player who has predicted.
+  const pot =
+    (leagueId != null ? WC_LEAGUES[leagueId]?.pot : undefined) ??
+    standings.length * 10;
+
   return (
     <Card className="rounded-xl bg-white shadow-sm">
       <CardContent className="p-4">
-        <h3 className="text-sm font-bold uppercase tracking-wide text-gray-500 mb-3">
-          Standings
-        </h3>
+        <div className="flex items-baseline justify-between mb-3">
+          <h3 className="text-sm font-bold uppercase tracking-wide text-gray-500">
+            Standings
+          </h3>
+          {!isLoading && (
+            <span className="text-sm font-semibold text-gray-800">
+              £{pot.toLocaleString('en-GB')} pot
+            </span>
+          )}
+        </div>
 
         {isLoading ? (
           <p className="text-sm text-muted-foreground text-center py-4">

--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -17,7 +17,8 @@ import useWcKnockoutPicks from 'app/hooks/useWcKnockoutPicks';
 import useWcKnockoutStandings from 'app/hooks/useWcKnockoutStandings';
 import {
   WC_ROUND_DEADLINES,
-  WC_ROUND_FIXTURE_LABELS
+  WC_ROUND_FIXTURE_LABELS,
+  getKnockoutDeadline
 } from '@/lib/wc-constants';
 
 // ─── FPL Last Player Standing (commented out for WC summer) ──────────────────
@@ -149,6 +150,16 @@ const Page = () => {
         now < WC_ROUND_DEADLINES[r] &&
         !wcPicks.some((p) => p.round_number === r)
     );
+
+  // Knockout deadlines are derived from each round's predicted fixture kickoff.
+  const knockoutDeadlineByRound: Record<number, Date> = {};
+  for (const f of wcKnockoutFixtures) {
+    if (f.is_predicted) {
+      knockoutDeadlineByRound[f.round_number] = getKnockoutDeadline(
+        f.kickoff_time
+      );
+    }
+  }
 
   return (
     <main>
@@ -393,7 +404,9 @@ const Page = () => {
                           <td
                             className={`px-4 py-3 text-right whitespace-nowrap ${r === 11 ? 'text-amber-600' : 'text-gray-500'}`}
                           >
-                            {formatDeadline(WC_ROUND_DEADLINES[r])}
+                            {knockoutDeadlineByRound[r]
+                              ? formatDeadline(knockoutDeadlineByRound[r])
+                              : 'TBC'}
                           </td>
                         </tr>
                       ))}

--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -1,14 +1,19 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { useSession } from 'next-auth/react';
 import WcPicksForm from './wc-picks-form';
+import GameSelector from './game-selector';
 import useWcFixtures from 'app/hooks/useWcFixtures';
 import useWcPicks from 'app/hooks/useWcPicks';
-import { WC_ROUND_DEADLINES, WC_ROUND_FIXTURE_LABELS } from '@/lib/wc-constants';
+import useWcLeagues from 'app/hooks/useWcLeagues';
+import {
+  WC_ROUND_DEADLINES,
+  WC_ROUND_FIXTURE_LABELS
+} from '@/lib/wc-constants';
 
 // ─── FPL Last Player Standing (commented out for WC summer) ──────────────────
 // import { useEffect, useMemo, useState } from 'react';
@@ -77,9 +82,15 @@ function SignInCard() {
         </Button>
         <p className="text-xs text-muted-foreground">
           By signing in, you agree to the{' '}
-          <a href="/privacy" target="_blank" rel="noopener noreferrer" className="underline">
+          <a
+            href="/privacy"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline"
+          >
             privacy policy
-          </a>.
+          </a>
+          .
         </p>
       </CardContent>
     </Card>
@@ -91,10 +102,33 @@ const Page = () => {
   const [refreshTrigger, setRefreshTrigger] = useState(0);
   const { wcFixtures, isLoadingWcFixtures } = useWcFixtures();
   const { wcPicks, isLoadingWcPicks } = useWcPicks({ refreshTrigger });
+  const { wcLeagues } = useWcLeagues();
+
+  const [selectedLeagueId, setSelectedLeagueId] = useState<number | null>(null);
+
+  // Default to the user's active game: survivors → Game 1, everyone else → Game 2.
+  useEffect(() => {
+    if (selectedLeagueId !== null || wcLeagues.length === 0) return;
+    const eligible = wcLeagues.filter((l) => l.eligible);
+    const primary =
+      eligible.find((l) => !l.knockout_only) ?? eligible[0] ?? wcLeagues[0];
+    setSelectedLeagueId(primary.league_id);
+  }, [wcLeagues, selectedLeagueId]);
+
+  const selectedLeague =
+    wcLeagues.find((l) => l.league_id === selectedLeagueId) ?? null;
+  const knockoutOnly = selectedLeague?.knockout_only ?? false;
+
+  // The group stage belongs to the original game only — leave that tab if a
+  // knockout-only game becomes selected.
+  useEffect(() => {
+    if (knockoutOnly && activeTab === 'group-stage') setActiveTab('rules');
+  }, [knockoutOnly, activeTab]);
 
   // Amber dot: any open round (deadline not passed) has no saved pick
   const now = new Date();
   const showGroupStageIndicator =
+    !knockoutOnly &&
     !isLoadingWcPicks &&
     [1, 2, 3, 4, 5, 6].some(
       (r) =>
@@ -112,6 +146,11 @@ const Page = () => {
         <p className="text-center text-xl font-light italic px-4 py-2">
           Survive the group stage then accumulate the most points to win.
         </p>
+        <GameSelector
+          leagues={wcLeagues}
+          selectedLeagueId={selectedLeagueId}
+          onSelect={setSelectedLeagueId}
+        />
       </div>
 
       {/* ── Tabs ─────────────────────────────────────────────────────────── */}
@@ -120,12 +159,14 @@ const Page = () => {
           <TabsTrigger value="rules" className="flex-1">
             Rules
           </TabsTrigger>
-          <TabsTrigger value="group-stage" className="flex-1">
-            Group Stage
-            {showGroupStageIndicator && (
-              <span className="ml-1.5 h-2 w-2 rounded-full bg-amber-400 inline-block" />
-            )}
-          </TabsTrigger>
+          {!knockoutOnly && (
+            <TabsTrigger value="group-stage" className="flex-1">
+              Group Stage
+              {showGroupStageIndicator && (
+                <span className="ml-1.5 h-2 w-2 rounded-full bg-amber-400 inline-block" />
+              )}
+            </TabsTrigger>
+          )}
           <TabsTrigger value="knockout" className="flex-1">
             Knockout
           </TabsTrigger>
@@ -134,7 +175,6 @@ const Page = () => {
         {/* ── Rules tab ──────────────────────────────────────────────────── */}
         <TabsContent value="rules">
           <div className="flex flex-col gap-6 text-sm text-gray-700 leading-relaxed">
-
             {/* Sign-in CTA — only shown to guests */}
             <SignInCard />
 
@@ -142,36 +182,64 @@ const Page = () => {
             <Card className="rounded-xl bg-white shadow-sm">
               <CardContent className="p-6 flex flex-col gap-4">
                 <div className="flex flex-wrap gap-2 justify-center">
-                  <span className="px-3 py-1 rounded-full bg-amber-400 text-white text-xs font-semibold">£10 entry</span>
-                  <span className="px-3 py-1 rounded-full bg-gray-800 text-white text-xs font-semibold">Winner takes all</span>
-                  <span className="px-3 py-1 rounded-full bg-gray-800 text-white text-xs font-semibold">11 rounds</span>
+                  <span className="px-3 py-1 rounded-full bg-amber-400 text-white text-xs font-semibold">
+                    £10 entry
+                  </span>
+                  <span className="px-3 py-1 rounded-full bg-gray-800 text-white text-xs font-semibold">
+                    Winner takes all
+                  </span>
+                  <span className="px-3 py-1 rounded-full bg-gray-800 text-white text-xs font-semibold">
+                    11 rounds
+                  </span>
                 </div>
                 <p>The game has two phases:</p>
                 <ol className="flex flex-col gap-3">
                   <li className="flex gap-3">
-                    <span className="font-bold text-gray-400 shrink-0 w-4">1</span>
+                    <span className="font-bold text-gray-400 shrink-0 w-4">
+                      1
+                    </span>
                     <div>
-                      <p className="font-semibold text-gray-900">Group Stage — Last Player Standing style</p>
-                      <p className="text-muted-foreground text-xs mt-0.5">Predict 6 teams to win, incorrect prediction? You&apos;re eliminated. Standard LPS stuff.</p>
+                      <p className="font-semibold text-gray-900">
+                        Group Stage — Last Player Standing style
+                      </p>
+                      <p className="text-muted-foreground text-xs mt-0.5">
+                        Predict 6 teams to win, incorrect prediction?
+                        You&apos;re eliminated. Standard LPS stuff.
+                      </p>
                     </div>
                   </li>
                   <li className="flex gap-3">
-                    <span className="font-bold text-gray-400 shrink-0 w-4">2</span>
+                    <span className="font-bold text-gray-400 shrink-0 w-4">
+                      2
+                    </span>
                     <div>
-                      <p className="font-semibold text-gray-900">Knockout Stage — Score Prediction</p>
-                      <p className="text-muted-foreground text-xs mt-0.5">Predict the score of predefined knockout stage matches. Earn 5 points for the correct score and 2 points for the correct outcome. Highest points total after The Final wins the pot!</p>
+                      <p className="font-semibold text-gray-900">
+                        Knockout Stage — Score Prediction
+                      </p>
+                      <p className="text-muted-foreground text-xs mt-0.5">
+                        Predict the score of predefined knockout stage matches.
+                        Earn 5 points for the correct score and 2 points for the
+                        correct outcome. Highest points total after The Final
+                        wins the pot!
+                      </p>
                     </div>
                   </li>
                 </ol>
-                <p className="text-muted-foreground text-xs">Details below...</p>
+                <p className="text-muted-foreground text-xs">
+                  Details below...
+                </p>
               </CardContent>
             </Card>
 
             {/* Phase 1 */}
             <Card className="rounded-xl bg-white shadow-sm overflow-hidden">
               <div className="border-l-4 border-amber-400 px-6 py-4 bg-amber-50">
-                <p className="text-xs font-bold tracking-widest text-amber-600 uppercase mb-0.5">Phase 1 · Rounds 1–6</p>
-                <h3 className="text-lg font-bold text-gray-900">The Group Stage</h3>
+                <p className="text-xs font-bold tracking-widest text-amber-600 uppercase mb-0.5">
+                  Phase 1 · Rounds 1–6
+                </p>
+                <h3 className="text-lg font-bold text-gray-900">
+                  The Group Stage
+                </h3>
                 <button
                   onClick={() => setActiveTab('group-stage')}
                   className="mt-2 text-xs font-semibold text-amber-700 underline underline-offset-2 hover:text-amber-900 transition-colors"
@@ -181,10 +249,13 @@ const Page = () => {
               </div>
               <CardContent className="p-6 flex flex-col gap-4">
                 <p>
-                  The group stage is split into 6 rounds. Each round, pick a team to <strong>win</strong> from that round&apos;s fixtures. Incorrect prediction? Eliminated. Standard LPS stuff.
+                  The group stage is split into 6 rounds. Each round, pick a
+                  team to <strong>win</strong> from that round&apos;s fixtures.
+                  Incorrect prediction? Eliminated. Standard LPS stuff.
                 </p>
                 <p className="text-muted-foreground">
-                  You can submit all 6 picks upfront and amend them right up to each round&apos;s deadline.
+                  You can submit all 6 picks upfront and amend them right up to
+                  each round&apos;s deadline.
                 </p>
 
                 {/* Round table */}
@@ -192,17 +263,32 @@ const Page = () => {
                   <table className="w-full text-xs">
                     <thead>
                       <tr className="bg-gray-50 border-b border-gray-200">
-                        <th className="text-left px-4 py-2.5 font-semibold text-gray-500 uppercase tracking-wide w-16">Round</th>
-                        <th className="text-left px-4 py-2.5 font-semibold text-gray-500 uppercase tracking-wide">Fixtures</th>
-                        <th className="text-right px-4 py-2.5 font-semibold text-gray-500 uppercase tracking-wide">Deadline</th>
+                        <th className="text-left px-4 py-2.5 font-semibold text-gray-500 uppercase tracking-wide w-16">
+                          Round
+                        </th>
+                        <th className="text-left px-4 py-2.5 font-semibold text-gray-500 uppercase tracking-wide">
+                          Fixtures
+                        </th>
+                        <th className="text-right px-4 py-2.5 font-semibold text-gray-500 uppercase tracking-wide">
+                          Deadline
+                        </th>
                       </tr>
                     </thead>
                     <tbody>
                       {[1, 2, 3, 4, 5, 6].map((r) => (
-                        <tr key={r} className="border-b border-gray-100 last:border-0">
-                          <td className="px-4 py-3 font-semibold text-gray-800">{r}</td>
-                          <td className="px-4 py-3 text-gray-700">{WC_ROUND_FIXTURE_LABELS[r]}</td>
-                          <td className="px-4 py-3 text-right text-gray-500 whitespace-nowrap">{formatDeadline(WC_ROUND_DEADLINES[r])}</td>
+                        <tr
+                          key={r}
+                          className="border-b border-gray-100 last:border-0"
+                        >
+                          <td className="px-4 py-3 font-semibold text-gray-800">
+                            {r}
+                          </td>
+                          <td className="px-4 py-3 text-gray-700">
+                            {WC_ROUND_FIXTURE_LABELS[r]}
+                          </td>
+                          <td className="px-4 py-3 text-right text-gray-500 whitespace-nowrap">
+                            {formatDeadline(WC_ROUND_DEADLINES[r])}
+                          </td>
                         </tr>
                       ))}
                     </tbody>
@@ -212,8 +298,13 @@ const Page = () => {
                 {/* No duplicate callout */}
                 <div className="rounded-lg bg-amber-50 border border-amber-200 px-4 py-3">
                   <p>
-                    <strong className="text-amber-800">No duplicate teams:</strong>{' '}
-                    <span className="text-amber-700">you can&apos;t pick the same team more than once across your 6 group stage picks.</span>
+                    <strong className="text-amber-800">
+                      No duplicate teams:
+                    </strong>{' '}
+                    <span className="text-amber-700">
+                      you can&apos;t pick the same team more than once across
+                      your 6 group stage picks.
+                    </span>
                   </p>
                 </div>
               </CardContent>
@@ -222,23 +313,34 @@ const Page = () => {
             {/* Phase 2 */}
             <Card className="rounded-xl bg-white shadow-sm overflow-hidden">
               <div className="border-l-4 border-green-500 px-6 py-4 bg-green-50">
-                <p className="text-xs font-bold tracking-widest text-green-600 uppercase mb-0.5">Phase 2 · Rounds 7–11</p>
-                <h3 className="text-lg font-bold text-gray-900">The Knockout Stage</h3>
+                <p className="text-xs font-bold tracking-widest text-green-600 uppercase mb-0.5">
+                  Phase 2 · Rounds 7–11
+                </p>
+                <h3 className="text-lg font-bold text-gray-900">
+                  The Knockout Stage
+                </h3>
               </div>
               <CardContent className="p-6 flex flex-col gap-4">
                 <p>
-                  Survive the group stage and you&apos;re in with a shot at winning. Each knockout round, everyone predicts the score of the same match. Points accumulate and the highest total after The Final takes the pot.
+                  Survive the group stage and you&apos;re in with a shot at
+                  winning. Each knockout round, everyone predicts the score of
+                  the same match. Points accumulate and the highest total after
+                  The Final takes the pot.
                 </p>
 
                 {/* Points cards */}
                 <div className="grid grid-cols-2 gap-3">
                   <div className="rounded-lg border-2 border-green-200 bg-green-50 p-4 text-center">
                     <p className="text-2xl font-bold text-green-700">5 pts</p>
-                    <p className="text-xs text-green-600 mt-0.5">Correct score</p>
+                    <p className="text-xs text-green-600 mt-0.5">
+                      Correct score
+                    </p>
                   </div>
                   <div className="rounded-lg border-2 border-amber-200 bg-amber-50 p-4 text-center">
                     <p className="text-2xl font-bold text-amber-700">2 pts</p>
-                    <p className="text-xs text-amber-600 mt-0.5">Correct result</p>
+                    <p className="text-xs text-amber-600 mt-0.5">
+                      Correct result
+                    </p>
                   </div>
                 </div>
 
@@ -247,17 +349,38 @@ const Page = () => {
                   <table className="w-full text-xs">
                     <thead>
                       <tr className="bg-gray-50 border-b border-gray-200">
-                        <th className="text-left px-4 py-2.5 font-semibold text-gray-500 uppercase tracking-wide w-16">Round</th>
-                        <th className="text-left px-4 py-2.5 font-semibold text-gray-500 uppercase tracking-wide">Fixtures</th>
-                        <th className="text-right px-4 py-2.5 font-semibold text-gray-500 uppercase tracking-wide">Deadline</th>
+                        <th className="text-left px-4 py-2.5 font-semibold text-gray-500 uppercase tracking-wide w-16">
+                          Round
+                        </th>
+                        <th className="text-left px-4 py-2.5 font-semibold text-gray-500 uppercase tracking-wide">
+                          Fixtures
+                        </th>
+                        <th className="text-right px-4 py-2.5 font-semibold text-gray-500 uppercase tracking-wide">
+                          Deadline
+                        </th>
                       </tr>
                     </thead>
                     <tbody>
                       {[7, 8, 9, 10, 11].map((r) => (
-                        <tr key={r} className={`border-b border-gray-100 last:border-0 ${r === 11 ? 'bg-amber-50' : ''}`}>
-                          <td className={`px-4 py-3 font-semibold ${r === 11 ? 'text-amber-700' : 'text-gray-800'}`}>{r}</td>
-                          <td className={`px-4 py-3 ${r === 11 ? 'font-semibold text-amber-700' : 'text-gray-700'}`}>{WC_ROUND_FIXTURE_LABELS[r]}</td>
-                          <td className={`px-4 py-3 text-right whitespace-nowrap ${r === 11 ? 'text-amber-600' : 'text-gray-500'}`}>{formatDeadline(WC_ROUND_DEADLINES[r])}</td>
+                        <tr
+                          key={r}
+                          className={`border-b border-gray-100 last:border-0 ${r === 11 ? 'bg-amber-50' : ''}`}
+                        >
+                          <td
+                            className={`px-4 py-3 font-semibold ${r === 11 ? 'text-amber-700' : 'text-gray-800'}`}
+                          >
+                            {r}
+                          </td>
+                          <td
+                            className={`px-4 py-3 ${r === 11 ? 'font-semibold text-amber-700' : 'text-gray-700'}`}
+                          >
+                            {WC_ROUND_FIXTURE_LABELS[r]}
+                          </td>
+                          <td
+                            className={`px-4 py-3 text-right whitespace-nowrap ${r === 11 ? 'text-amber-600' : 'text-gray-500'}`}
+                          >
+                            {formatDeadline(WC_ROUND_DEADLINES[r])}
+                          </td>
                         </tr>
                       ))}
                     </tbody>
@@ -265,7 +388,6 @@ const Page = () => {
                 </div>
               </CardContent>
             </Card>
-
           </div>
         </TabsContent>
 
@@ -289,9 +411,14 @@ const Page = () => {
           <Card className="rounded-xl bg-white shadow-sm">
             <CardContent className="p-12 flex flex-col items-center gap-3 text-center">
               <p className="text-4xl">🏆</p>
-              <p className="text-lg font-semibold text-gray-800">Knockout stage — coming soon</p>
+              <p className="text-lg font-semibold text-gray-800">
+                Knockout stage — coming soon
+              </p>
               <p className="text-sm text-muted-foreground max-w-sm">
-                Everyone who survives the group stage will predict the score of the same match each round — the last fixture played in that round. 5 points for a correct score, 2 for the correct result. The highest points total after The Final wins.
+                Everyone who survives the group stage will predict the score of
+                the same match each round — the last fixture played in that
+                round. 5 points for a correct score, 2 for the correct result.
+                The highest points total after The Final wins.
               </p>
               <p className="text-sm text-muted-foreground max-w-sm">
                 Check back after 27 June when the group stage is complete.

--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -451,6 +451,7 @@ const Page = () => {
               <KnockoutStandings
                 standings={wcKnockoutStandings}
                 isLoading={isLoadingWcKnockoutStandings}
+                leagueId={selectedLeagueId}
               />
             </div>
           </div>

--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -7,12 +7,14 @@ import { Button } from '@/components/ui/button';
 import { useSession } from 'next-auth/react';
 import WcPicksForm from './wc-picks-form';
 import KnockoutPicksForm from './knockout-picks-form';
+import KnockoutStandings from './knockout-standings';
 import GameSelector from './game-selector';
 import useWcFixtures from 'app/hooks/useWcFixtures';
 import useWcPicks from 'app/hooks/useWcPicks';
 import useWcLeagues from 'app/hooks/useWcLeagues';
 import useWcKnockoutFixtures from 'app/hooks/useWcKnockoutFixtures';
 import useWcKnockoutPicks from 'app/hooks/useWcKnockoutPicks';
+import useWcKnockoutStandings from 'app/hooks/useWcKnockoutStandings';
 import {
   WC_ROUND_DEADLINES,
   WC_ROUND_FIXTURE_LABELS
@@ -115,6 +117,8 @@ const Page = () => {
     leagueId: selectedLeagueId,
     refreshTrigger
   });
+  const { wcKnockoutStandings, isLoadingWcKnockoutStandings } =
+    useWcKnockoutStandings({ leagueId: selectedLeagueId, refreshTrigger });
 
   // Default to the user's active game: survivors → Game 1, everyone else → Game 2.
   useEffect(() => {
@@ -418,15 +422,25 @@ const Page = () => {
 
         {/* ── Knockout tab ───────────────────────────────────────────────── */}
         <TabsContent value="knockout">
-          <KnockoutPicksForm
-            leagueId={selectedLeagueId}
-            eligible={selectedLeague?.eligible ?? false}
-            fixtures={wcKnockoutFixtures}
-            isLoadingFixtures={isLoadingWcKnockoutFixtures}
-            picks={wcKnockoutPicks}
-            isLoadingPicks={isLoadingWcKnockoutPicks}
-            setRefreshTrigger={setRefreshTrigger}
-          />
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4 items-start">
+            <div className="md:col-span-2">
+              <KnockoutPicksForm
+                leagueId={selectedLeagueId}
+                eligible={selectedLeague?.eligible ?? false}
+                fixtures={wcKnockoutFixtures}
+                isLoadingFixtures={isLoadingWcKnockoutFixtures}
+                picks={wcKnockoutPicks}
+                isLoadingPicks={isLoadingWcKnockoutPicks}
+                setRefreshTrigger={setRefreshTrigger}
+              />
+            </div>
+            <div className="md:col-span-1 md:sticky md:top-4">
+              <KnockoutStandings
+                standings={wcKnockoutStandings}
+                isLoading={isLoadingWcKnockoutStandings}
+              />
+            </div>
+          </div>
         </TabsContent>
       </Tabs>
 

--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -6,10 +6,13 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { useSession } from 'next-auth/react';
 import WcPicksForm from './wc-picks-form';
+import KnockoutPicksForm from './knockout-picks-form';
 import GameSelector from './game-selector';
 import useWcFixtures from 'app/hooks/useWcFixtures';
 import useWcPicks from 'app/hooks/useWcPicks';
 import useWcLeagues from 'app/hooks/useWcLeagues';
+import useWcKnockoutFixtures from 'app/hooks/useWcKnockoutFixtures';
+import useWcKnockoutPicks from 'app/hooks/useWcKnockoutPicks';
 import {
   WC_ROUND_DEADLINES,
   WC_ROUND_FIXTURE_LABELS
@@ -105,6 +108,13 @@ const Page = () => {
   const { wcLeagues } = useWcLeagues();
 
   const [selectedLeagueId, setSelectedLeagueId] = useState<number | null>(null);
+
+  const { wcKnockoutFixtures, isLoadingWcKnockoutFixtures } =
+    useWcKnockoutFixtures();
+  const { wcKnockoutPicks, isLoadingWcKnockoutPicks } = useWcKnockoutPicks({
+    leagueId: selectedLeagueId,
+    refreshTrigger
+  });
 
   // Default to the user's active game: survivors → Game 1, everyone else → Game 2.
   useEffect(() => {
@@ -408,23 +418,15 @@ const Page = () => {
 
         {/* ── Knockout tab ───────────────────────────────────────────────── */}
         <TabsContent value="knockout">
-          <Card className="rounded-xl bg-white shadow-sm">
-            <CardContent className="p-12 flex flex-col items-center gap-3 text-center">
-              <p className="text-4xl">🏆</p>
-              <p className="text-lg font-semibold text-gray-800">
-                Knockout stage — coming soon
-              </p>
-              <p className="text-sm text-muted-foreground max-w-sm">
-                Everyone who survives the group stage will predict the score of
-                the same match each round — the last fixture played in that
-                round. 5 points for a correct score, 2 for the correct result.
-                The highest points total after The Final wins.
-              </p>
-              <p className="text-sm text-muted-foreground max-w-sm">
-                Check back after 27 June when the group stage is complete.
-              </p>
-            </CardContent>
-          </Card>
+          <KnockoutPicksForm
+            leagueId={selectedLeagueId}
+            eligible={selectedLeague?.eligible ?? false}
+            fixtures={wcKnockoutFixtures}
+            isLoadingFixtures={isLoadingWcKnockoutFixtures}
+            picks={wcKnockoutPicks}
+            isLoadingPicks={isLoadingWcKnockoutPicks}
+            setRefreshTrigger={setRefreshTrigger}
+          />
         </TabsContent>
       </Tabs>
 

--- a/app/api/wc/knockout/admin/route.ts
+++ b/app/api/wc/knockout/admin/route.ts
@@ -35,8 +35,13 @@ export async function PATCH(request: Request) {
       );
     }
 
-    const { rows: fixtures } = await sql.query<{ is_complete: boolean }>(
-      `SELECT is_complete FROM wc_knockout_fixtures WHERE id = $1`,
+    const { rows: fixtures } = await sql.query<{
+      round_number: number;
+      is_predicted: boolean;
+      is_complete: boolean;
+    }>(
+      `SELECT round_number, is_predicted, is_complete
+       FROM wc_knockout_fixtures WHERE id = $1`,
       [fixture_id]
     );
     if (!fixtures.length) {
@@ -45,7 +50,11 @@ export async function PATCH(request: Request) {
         { status: 404 }
       );
     }
-    const was_complete = fixtures[0].is_complete;
+    const {
+      round_number: roundNumber,
+      is_predicted: isPredicted,
+      is_complete: was_complete
+    } = fixtures[0];
 
     // Atomically record the result and (re)score every prediction on it, so we
     // can't end up with a completed fixture whose picks were never scored. Picks
@@ -61,34 +70,39 @@ export async function PATCH(request: Request) {
         [home_team_score, away_team_score, fixture_id]
       );
 
-      const { rows: picks } = await client.query<{
-        user_id: number;
-        league_id: number;
-        round_number: number;
-        home_score: number;
-        away_score: number;
-      }>(
-        `SELECT user_id, league_id, round_number, home_score, away_score
-         FROM wc_knockout_picks
-         WHERE fixture_id = $1`,
-        [fixture_id]
-      );
+      // Score picks by round (not fixture_id) so that moving the predicted flag
+      // to a different match never orphans previously-saved picks. Only the
+      // round's predicted match scores its picks.
+      if (isPredicted) {
+        const { rows: picks } = await client.query<{
+          user_id: number;
+          league_id: number;
+          round_number: number;
+          home_score: number;
+          away_score: number;
+        }>(
+          `SELECT user_id, league_id, round_number, home_score, away_score
+           FROM wc_knockout_picks
+           WHERE round_number = $1`,
+          [roundNumber]
+        );
 
-      for (const p of picks) {
-        const points = computeKnockoutPoints(
-          p.home_score,
-          p.away_score,
-          home_team_score,
-          away_team_score
-        );
-        await client.query(
-          `UPDATE wc_knockout_picks
-           SET points = $1
-           WHERE user_id = $2 AND league_id = $3 AND round_number = $4`,
-          [points, p.user_id, p.league_id, p.round_number]
-        );
+        for (const p of picks) {
+          const points = computeKnockoutPoints(
+            p.home_score,
+            p.away_score,
+            home_team_score,
+            away_team_score
+          );
+          await client.query(
+            `UPDATE wc_knockout_picks
+             SET points = $1
+             WHERE user_id = $2 AND league_id = $3 AND round_number = $4`,
+            [points, p.user_id, p.league_id, p.round_number]
+          );
+        }
+        picks_scored = picks.length;
       }
-      picks_scored = picks.length;
       await client.query('COMMIT');
     } catch (e) {
       await client.query('ROLLBACK');

--- a/app/api/wc/knockout/admin/route.ts
+++ b/app/api/wc/knockout/admin/route.ts
@@ -1,0 +1,112 @@
+import { sql, db } from '@vercel/postgres';
+import { auth } from '@/lib/auth';
+import { isAdminEmail } from '@/lib/admin';
+import { computeKnockoutPoints } from '@/lib/knockout';
+
+// PATCH /api/wc/knockout/admin
+// Records a knockout fixture's result and (re)scores every prediction on it
+// across ALL games (5 = exact score, 2 = correct result, 0 otherwise).
+// Body: { fixture_id, home_team_score, away_team_score }
+// Auth: WC_ADMIN_SECRET header (curl) or a signed-in admin session.
+
+export async function PATCH(request: Request) {
+  const secret = request.headers.get('x-admin-secret');
+  if (secret !== process.env.WC_ADMIN_SECRET) {
+    const session = await auth();
+    if (!isAdminEmail(session?.user?.email)) {
+      return Response.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+  }
+
+  try {
+    const body = await request.json();
+    const { fixture_id, home_team_score, away_team_score } = body;
+
+    if (
+      !Number.isInteger(fixture_id) ||
+      !Number.isInteger(home_team_score) ||
+      !Number.isInteger(away_team_score) ||
+      home_team_score < 0 ||
+      away_team_score < 0
+    ) {
+      return Response.json(
+        { error: 'fixture_id and non-negative integer scores are required' },
+        { status: 400 }
+      );
+    }
+
+    const { rows: fixtures } = await sql.query<{ is_complete: boolean }>(
+      `SELECT is_complete FROM wc_knockout_fixtures WHERE id = $1`,
+      [fixture_id]
+    );
+    if (!fixtures.length) {
+      return Response.json(
+        { error: `Knockout fixture ${fixture_id} not found` },
+        { status: 404 }
+      );
+    }
+    const was_complete = fixtures[0].is_complete;
+
+    // Atomically record the result and (re)score every prediction on it, so we
+    // can't end up with a completed fixture whose picks were never scored. Picks
+    // are recomputed from scratch, so a corrected score also corrects points.
+    const client = await db.connect();
+    let picks_scored = 0;
+    try {
+      await client.query('BEGIN');
+      await client.query(
+        `UPDATE wc_knockout_fixtures
+         SET home_team_score = $1, away_team_score = $2, is_complete = TRUE
+         WHERE id = $3`,
+        [home_team_score, away_team_score, fixture_id]
+      );
+
+      const { rows: picks } = await client.query<{
+        user_id: number;
+        league_id: number;
+        round_number: number;
+        home_score: number;
+        away_score: number;
+      }>(
+        `SELECT user_id, league_id, round_number, home_score, away_score
+         FROM wc_knockout_picks
+         WHERE fixture_id = $1`,
+        [fixture_id]
+      );
+
+      for (const p of picks) {
+        const points = computeKnockoutPoints(
+          p.home_score,
+          p.away_score,
+          home_team_score,
+          away_team_score
+        );
+        await client.query(
+          `UPDATE wc_knockout_picks
+           SET points = $1
+           WHERE user_id = $2 AND league_id = $3 AND round_number = $4`,
+          [points, p.user_id, p.league_id, p.round_number]
+        );
+      }
+      picks_scored = picks.length;
+      await client.query('COMMIT');
+    } catch (e) {
+      await client.query('ROLLBACK');
+      throw e;
+    } finally {
+      client.release();
+    }
+
+    return Response.json({
+      success: true,
+      fixture_id,
+      home_team_score,
+      away_team_score,
+      picks_scored,
+      was_complete
+    });
+  } catch (error) {
+    console.error('WC knockout admin error:', error);
+    return Response.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/app/api/wc/knockout/fixtures/route.ts
+++ b/app/api/wc/knockout/fixtures/route.ts
@@ -1,0 +1,34 @@
+import { sql } from '@vercel/postgres';
+import { WcKnockoutFixture } from '@/lib/wc-definitions';
+
+// All knockout fixtures (every match is stored for analysis; the one
+// is_predicted = true row per round is what players score-predict).
+export async function GET() {
+  try {
+    const { rows } = await sql.query<WcKnockoutFixture>(
+      `SELECT
+        id,
+        round_number,
+        match_label,
+        home_team_name,
+        away_team_name,
+        kickoff_time,
+        is_predicted,
+        home_team_score,
+        away_team_score,
+        is_complete
+      FROM wc_knockout_fixtures
+      ORDER BY round_number, kickoff_time`
+    );
+
+    return Response.json(rows, {
+      headers: { 'Cache-Control': 's-maxage=300' }
+    });
+  } catch (error) {
+    console.error('Error fetching WC knockout fixtures:', error);
+    return Response.json(
+      { error: 'Failed to fetch knockout fixtures' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/wc/knockout/fixtures/route.ts
+++ b/app/api/wc/knockout/fixtures/route.ts
@@ -1,5 +1,14 @@
-import { sql } from '@vercel/postgres';
+import { sql, db } from '@vercel/postgres';
+import { auth } from '@/lib/auth';
+import { isAdminEmail } from '@/lib/admin';
+import { WC_TEAMS } from '@/lib/wc-constants';
 import { WcKnockoutFixture } from '@/lib/wc-definitions';
+
+const VALID_TEAM_NAMES = new Set(WC_TEAMS.map((t) => t.name));
+
+const RETURN_COLUMNS = `id, round_number, match_label, home_team_name,
+  away_team_name, kickoff_time, is_predicted, home_team_score,
+  away_team_score, is_complete`;
 
 // All knockout fixtures (every match is stored for analysis; the one
 // is_predicted = true row per round is what players score-predict).
@@ -30,5 +39,123 @@ export async function GET() {
       { error: 'Failed to fetch knockout fixtures' },
       { status: 500 }
     );
+  }
+}
+
+// PATCH /api/wc/knockout/fixtures
+// Admin-only editor for a fixture's teams, kickoff, or predicted flag. Team names
+// must come from WC_TEAMS (or null = TBD). Setting is_predicted = true clears the
+// flag on the round's other fixtures so each round keeps exactly one predicted match.
+// Body: { fixture_id, home_team_name?, away_team_name?, kickoff_time?, is_predicted? }
+// Auth: WC_ADMIN_SECRET header (curl) or a signed-in admin session.
+export async function PATCH(request: Request) {
+  const secret = request.headers.get('x-admin-secret');
+  if (secret !== process.env.WC_ADMIN_SECRET) {
+    const session = await auth();
+    if (!isAdminEmail(session?.user?.email)) {
+      return Response.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+  }
+
+  try {
+    const body = await request.json();
+    const fixtureId = body.fixture_id;
+    if (!Number.isInteger(fixtureId)) {
+      return Response.json(
+        { error: 'fixture_id is required' },
+        { status: 400 }
+      );
+    }
+
+    // Build the partial update from whichever editable fields were provided.
+    const sets: string[] = [];
+    const values: unknown[] = [];
+    let i = 1;
+
+    for (const field of ['home_team_name', 'away_team_name'] as const) {
+      if (field in body) {
+        const v = body[field];
+        if (v !== null && !VALID_TEAM_NAMES.has(v)) {
+          return Response.json(
+            { error: `Invalid team name for ${field}` },
+            { status: 400 }
+          );
+        }
+        sets.push(`${field} = $${i++}`);
+        values.push(v);
+      }
+    }
+
+    if ('kickoff_time' in body) {
+      const v = body.kickoff_time;
+      if (typeof v !== 'string' || Number.isNaN(Date.parse(v))) {
+        return Response.json(
+          { error: 'kickoff_time must be a valid date string' },
+          { status: 400 }
+        );
+      }
+      sets.push(`kickoff_time = $${i++}`);
+      values.push(v);
+    }
+
+    if ('is_predicted' in body) {
+      if (typeof body.is_predicted !== 'boolean') {
+        return Response.json(
+          { error: 'is_predicted must be a boolean' },
+          { status: 400 }
+        );
+      }
+      sets.push(`is_predicted = $${i++}`);
+      values.push(body.is_predicted);
+    }
+
+    if (sets.length === 0) {
+      return Response.json({ error: 'No fields to update' }, { status: 400 });
+    }
+
+    const { rows: existing } = await sql.query<{ round_number: number }>(
+      `SELECT round_number FROM wc_knockout_fixtures WHERE id = $1`,
+      [fixtureId]
+    );
+    if (!existing.length) {
+      return Response.json(
+        { error: `Knockout fixture ${fixtureId} not found` },
+        { status: 404 }
+      );
+    }
+
+    const client = await db.connect();
+    try {
+      await client.query('BEGIN');
+
+      // Keep exactly one predicted match per round.
+      if (body.is_predicted === true) {
+        await client.query(
+          `UPDATE wc_knockout_fixtures
+           SET is_predicted = false
+           WHERE round_number = $1 AND id <> $2`,
+          [existing[0].round_number, fixtureId]
+        );
+      }
+
+      values.push(fixtureId);
+      const { rows } = await client.query<WcKnockoutFixture>(
+        `UPDATE wc_knockout_fixtures
+         SET ${sets.join(', ')}
+         WHERE id = $${i}
+         RETURNING ${RETURN_COLUMNS}`,
+        values
+      );
+      await client.query('COMMIT');
+      return Response.json(rows[0]);
+    } catch (e) {
+      await client.query('ROLLBACK');
+      throw e;
+    } finally {
+      client.release();
+    }
+  } catch (error) {
+    console.error('WC knockout fixture update error:', error);
+    return Response.json({ error: 'Internal server error' }, { status: 500 });
   }
 }

--- a/app/api/wc/knockout/leagues/route.ts
+++ b/app/api/wc/knockout/leagues/route.ts
@@ -1,0 +1,47 @@
+import { auth } from '@/lib/auth';
+import { sql } from '@vercel/postgres';
+import { WC_LEAGUES } from '@/lib/wc-constants';
+import { WcLeagueMembership } from '@/lib/wc-definitions';
+import { isSurvivor } from '@/lib/knockout';
+
+// The WC games the signed-in user belongs to, each flagged with whether they
+// may submit knockout picks there. Powers the game selector.
+export async function GET() {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const userId = session.user.id;
+
+  try {
+    const { rows } = await sql.query<{ league_id: number }>(
+      `SELECT league_id FROM user_leagues WHERE user_id = $1`,
+      [userId]
+    );
+
+    const memberships: WcLeagueMembership[] = [];
+    for (const { league_id } of rows) {
+      const meta = WC_LEAGUES[league_id];
+      if (!meta) continue; // ignore non-WC leagues (e.g. legacy FPL leagues)
+
+      // Knockout-only games are open to all; the original game is survivors-only.
+      const eligible = meta.knockoutOnly
+        ? true
+        : await isSurvivor(userId, league_id);
+
+      memberships.push({
+        league_id,
+        name: meta.name,
+        knockout_only: meta.knockoutOnly,
+        eligible
+      });
+    }
+
+    memberships.sort((a, b) => a.league_id - b.league_id);
+
+    return Response.json(memberships);
+  } catch (error) {
+    console.error('Error fetching WC leagues:', error);
+    return Response.json({ error: 'Failed to fetch leagues' }, { status: 500 });
+  }
+}

--- a/app/api/wc/knockout/picks/route.ts
+++ b/app/api/wc/knockout/picks/route.ts
@@ -5,6 +5,7 @@ import { KnockoutPickInput, WcKnockoutPick } from '@/lib/wc-definitions';
 import {
   WC_LEAGUES,
   WC_KNOCKOUT_ROUNDS,
+  WC_ROUND_FIXTURE_LABELS,
   getKnockoutDeadline
 } from '@/lib/wc-constants';
 import { isSurvivor } from '@/lib/knockout';
@@ -201,7 +202,7 @@ export async function POST(request: Request) {
           .map((p) => {
             const f = fixtureByRound.get(p.round_number);
             const matchup = `${f?.home_team_name ?? 'TBD'} v ${f?.away_team_name ?? 'TBD'}`;
-            return `<li><strong>Round ${p.round_number}</strong> (${matchup}): ${p.home_score}–${p.away_score}</li>`;
+            return `<li><strong>${WC_ROUND_FIXTURE_LABELS[p.round_number]}</strong> (${matchup}): ${p.home_score}–${p.away_score}</li>`;
           })
           .join('');
 

--- a/app/api/wc/knockout/picks/route.ts
+++ b/app/api/wc/knockout/picks/route.ts
@@ -1,0 +1,236 @@
+import { auth } from '@/lib/auth';
+import { sql } from '@vercel/postgres';
+import { Resend } from 'resend';
+import { KnockoutPickInput, WcKnockoutPick } from '@/lib/wc-definitions';
+import {
+  WC_LEAGUES,
+  WC_KNOCKOUT_ROUNDS,
+  getKnockoutDeadline
+} from '@/lib/wc-constants';
+import { isSurvivor } from '@/lib/knockout';
+
+const KNOCKOUT_ROUNDS = new Set<number>(WC_KNOCKOUT_ROUNDS);
+
+// Confirm the signed-in user belongs to the given league.
+async function isMember(userId: string, leagueId: number): Promise<boolean> {
+  const { rows } = await sql.query(
+    `SELECT 1 FROM user_leagues WHERE user_id = $1 AND league_id = $2 LIMIT 1`,
+    [userId, leagueId]
+  );
+  return rows.length > 0;
+}
+
+// ── GET: the user's knockout picks for a league ──────────────────────────────
+
+export async function GET(request: Request) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const userId = session.user.id;
+
+  const leagueId = Number(new URL(request.url).searchParams.get('league_id'));
+  if (!Number.isInteger(leagueId) || !WC_LEAGUES[leagueId]) {
+    return Response.json({ error: 'Invalid league_id' }, { status: 400 });
+  }
+  if (!(await isMember(userId, leagueId))) {
+    return Response.json(
+      { error: 'Not a member of this league' },
+      { status: 403 }
+    );
+  }
+
+  try {
+    const { rows } = await sql.query<WcKnockoutPick>(
+      `SELECT
+        round_number,
+        fixture_id,
+        home_score,
+        away_score,
+        points,
+        submitted_at,
+        last_amended_at
+      FROM wc_knockout_picks
+      WHERE user_id = $1 AND league_id = $2
+      ORDER BY round_number`,
+      [userId, leagueId]
+    );
+    return Response.json(rows);
+  } catch (error) {
+    console.error('Error fetching WC knockout picks:', error);
+    return Response.json({ error: 'Failed to fetch picks' }, { status: 500 });
+  }
+}
+
+// ── POST: submit / amend knockout score predictions ──────────────────────────
+
+export async function POST(request: Request) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const userId = session.user.id;
+  const userEmail = session.user.email;
+  const userName = session.user.user_name || 'there';
+
+  try {
+    const body = await request.json();
+    const leagueId: number = body.league_id;
+    const picks: KnockoutPickInput[] = body.picks;
+
+    const leagueMeta = WC_LEAGUES[leagueId];
+    if (!Number.isInteger(leagueId) || !leagueMeta) {
+      return Response.json({ error: 'Invalid league_id' }, { status: 400 });
+    }
+    if (!Array.isArray(picks) || picks.length === 0) {
+      return Response.json({ error: 'No picks provided' }, { status: 400 });
+    }
+    if (!(await isMember(userId, leagueId))) {
+      return Response.json(
+        { error: 'Not a member of this league' },
+        { status: 403 }
+      );
+    }
+
+    // Eligibility: the original game is survivors-only; the parallel game is open.
+    if (!leagueMeta.knockoutOnly && !(await isSurvivor(userId, leagueId))) {
+      return Response.json(
+        { error: 'You are not eligible to play the knockout in this game' },
+        { status: 403 }
+      );
+    }
+
+    // Round numbers must be knockout rounds and unique within the submission.
+    const roundNumbers = picks.map((p) => p.round_number);
+    if (roundNumbers.some((r) => !KNOCKOUT_ROUNDS.has(r))) {
+      return Response.json(
+        { error: 'Round number must be a knockout round (7–11)' },
+        { status: 400 }
+      );
+    }
+    if (new Set(roundNumbers).size !== roundNumbers.length) {
+      return Response.json(
+        { error: 'Duplicate round numbers in submission' },
+        { status: 400 }
+      );
+    }
+
+    // Scores must be sensible non-negative integers.
+    for (const pick of picks) {
+      for (const score of [pick.home_score, pick.away_score]) {
+        if (!Number.isInteger(score) || score < 0 || score > 99) {
+          return Response.json(
+            { error: 'Scores must be whole numbers between 0 and 99' },
+            { status: 400 }
+          );
+        }
+      }
+    }
+
+    // Load the predicted fixture for each submitted round.
+    const { rows: fixtures } = await sql.query<{
+      id: number;
+      round_number: number;
+      home_team_name: string | null;
+      away_team_name: string | null;
+      kickoff_time: string;
+    }>(
+      `SELECT id, round_number, home_team_name, away_team_name, kickoff_time
+       FROM wc_knockout_fixtures
+       WHERE round_number = ANY($1::int[]) AND is_predicted = true`,
+      [roundNumbers]
+    );
+    const fixtureByRound = new Map(fixtures.map((f) => [f.round_number, f]));
+
+    const now = new Date();
+    for (const pick of picks) {
+      const fixture = fixtureByRound.get(pick.round_number);
+      if (!fixture) {
+        return Response.json(
+          { error: `No predicted fixture for Round ${pick.round_number}` },
+          { status: 400 }
+        );
+      }
+      if (fixture.id !== pick.fixture_id) {
+        return Response.json(
+          {
+            error: `Fixture ${pick.fixture_id} is not the predicted match for Round ${pick.round_number}`
+          },
+          { status: 400 }
+        );
+      }
+      if (now > getKnockoutDeadline(fixture.kickoff_time)) {
+        return Response.json(
+          { error: `Deadline has passed for Round ${pick.round_number}` },
+          { status: 400 }
+        );
+      }
+    }
+
+    // Upsert — never overwrite a pick that has already been scored (points set).
+    let savedCount = 0;
+    for (const pick of picks) {
+      const result = await sql.query(
+        `INSERT INTO wc_knockout_picks
+           (user_id, league_id, round_number, fixture_id, home_score, away_score)
+         VALUES ($1, $2, $3, $4, $5, $6)
+         ON CONFLICT (user_id, league_id, round_number)
+         DO UPDATE SET
+           home_score      = EXCLUDED.home_score,
+           away_score      = EXCLUDED.away_score,
+           last_amended_at = NOW()
+         WHERE wc_knockout_picks.points IS NULL`,
+        [
+          userId,
+          leagueId,
+          pick.round_number,
+          pick.fixture_id,
+          pick.home_score,
+          pick.away_score
+        ]
+      );
+      savedCount += result.rowCount ?? 0;
+    }
+
+    // Confirmation email (best-effort).
+    if (userEmail) {
+      try {
+        const pickLines = picks
+          .slice()
+          .sort((a, b) => a.round_number - b.round_number)
+          .map((p) => {
+            const f = fixtureByRound.get(p.round_number);
+            const matchup = `${f?.home_team_name ?? 'TBD'} v ${f?.away_team_name ?? 'TBD'}`;
+            return `<li><strong>Round ${p.round_number}</strong> (${matchup}): ${p.home_score}–${p.away_score}</li>`;
+          })
+          .join('');
+
+        const adminEmail = process.env.NEXT_PUBLIC_MY_EMAIL_ADDRESS;
+        const resend = new Resend(process.env.AUTH_RESEND_KEY);
+        await resend.emails.send({
+          from: 'Last Player Standing <noreply@lmsiq.co.uk>',
+          to: [userEmail],
+          ...(adminEmail && { bcc: [adminEmail] }),
+          subject: `${leagueMeta.name} — knockout predictions saved`,
+          html: `
+            <h2>Hey ${userName} 👋🏻</h2>
+            <p>Your knockout score predictions for <strong>${leagueMeta.name}</strong> have been saved!</p>
+            <ul>${pickLines}</ul>
+            <p>You can amend a prediction up to 1 hour before that match kicks off.</p>
+            ${adminEmail ? `<p>If something looks wrong, email <a href="mailto:${adminEmail}">${adminEmail}</a></p>` : ''}
+          `
+        });
+      } catch (emailError) {
+        console.error(
+          'Failed to send WC knockout confirmation email:',
+          emailError
+        );
+      }
+    }
+
+    return Response.json({ success: true, savedCount }, { status: 201 });
+  } catch (error) {
+    console.error('Error saving WC knockout picks:', error);
+    return Response.json({ error: 'Failed to save picks' }, { status: 500 });
+  }
+}

--- a/app/api/wc/knockout/picks/route.ts
+++ b/app/api/wc/knockout/picks/route.ts
@@ -1,5 +1,5 @@
 import { auth } from '@/lib/auth';
-import { sql } from '@vercel/postgres';
+import { sql, db } from '@vercel/postgres';
 import { Resend } from 'resend';
 import { KnockoutPickInput, WcKnockoutPick } from '@/lib/wc-definitions';
 import {
@@ -168,29 +168,42 @@ export async function POST(request: Request) {
       }
     }
 
-    // Upsert — never overwrite a pick that has already been scored (points set).
+    // Upsert all rounds atomically — never overwrite a pick that has already
+    // been scored (points set). fixture_id is rewritten on conflict so an
+    // amendment re-points the pick at the current predicted fixture.
     let savedCount = 0;
-    for (const pick of picks) {
-      const result = await sql.query(
-        `INSERT INTO wc_knockout_picks
-           (user_id, league_id, round_number, fixture_id, home_score, away_score)
-         VALUES ($1, $2, $3, $4, $5, $6)
-         ON CONFLICT (user_id, league_id, round_number)
-         DO UPDATE SET
-           home_score      = EXCLUDED.home_score,
-           away_score      = EXCLUDED.away_score,
-           last_amended_at = NOW()
-         WHERE wc_knockout_picks.points IS NULL`,
-        [
-          userId,
-          leagueId,
-          pick.round_number,
-          pick.fixture_id,
-          pick.home_score,
-          pick.away_score
-        ]
-      );
-      savedCount += result.rowCount ?? 0;
+    const client = await db.connect();
+    try {
+      await client.query('BEGIN');
+      for (const pick of picks) {
+        const result = await client.query(
+          `INSERT INTO wc_knockout_picks
+             (user_id, league_id, round_number, fixture_id, home_score, away_score)
+           VALUES ($1, $2, $3, $4, $5, $6)
+           ON CONFLICT (user_id, league_id, round_number)
+           DO UPDATE SET
+             fixture_id      = EXCLUDED.fixture_id,
+             home_score      = EXCLUDED.home_score,
+             away_score      = EXCLUDED.away_score,
+             last_amended_at = NOW()
+           WHERE wc_knockout_picks.points IS NULL`,
+          [
+            userId,
+            leagueId,
+            pick.round_number,
+            pick.fixture_id,
+            pick.home_score,
+            pick.away_score
+          ]
+        );
+        savedCount += result.rowCount ?? 0;
+      }
+      await client.query('COMMIT');
+    } catch (e) {
+      await client.query('ROLLBACK');
+      throw e;
+    } finally {
+      client.release();
     }
 
     // Confirmation email (best-effort).

--- a/app/api/wc/knockout/seed/route.ts
+++ b/app/api/wc/knockout/seed/route.ts
@@ -1,0 +1,137 @@
+import { sql } from '@vercel/postgres';
+
+// All 31 knockout matches (R32×16, R16×8, QF×4, SF×2, Final×1), times in UTC.
+// Teams are TBD (NULL) until the bracket resolves — the admin fills them in via
+// the team-name editor. The one is_predicted = true match per round (the last
+// match chronologically) is what players score-predict. Colombia v Ghana, the
+// confirmed last Round of 32 match, is pre-filled.
+//
+// round_number: 7 = R32, 8 = R16, 9 = QF, 10 = SF, 11 = Final.
+const KO_FIXTURES: {
+  round: number;
+  label: string;
+  ko: string;
+  predicted?: boolean;
+  home?: string;
+  away?: string;
+}[] = [
+  // ── Round of 32 (round 7) ──────────────────────────────────────────────
+  { round: 7, label: 'Round of 32 — Match 73', ko: '2026-06-28T19:00:00Z' },
+  { round: 7, label: 'Round of 32 — Match 76', ko: '2026-06-29T17:00:00Z' },
+  { round: 7, label: 'Round of 32 — Match 74', ko: '2026-06-29T20:30:00Z' },
+  { round: 7, label: 'Round of 32 — Match 75', ko: '2026-06-30T01:00:00Z' },
+  { round: 7, label: 'Round of 32 — Match 78', ko: '2026-06-30T17:00:00Z' },
+  { round: 7, label: 'Round of 32 — Match 77', ko: '2026-06-30T21:00:00Z' },
+  { round: 7, label: 'Round of 32 — Match 79', ko: '2026-07-01T01:00:00Z' },
+  { round: 7, label: 'Round of 32 — Match 80', ko: '2026-07-01T16:00:00Z' },
+  { round: 7, label: 'Round of 32 — Match 82', ko: '2026-07-01T20:00:00Z' },
+  { round: 7, label: 'Round of 32 — Match 81', ko: '2026-07-02T00:00:00Z' },
+  { round: 7, label: 'Round of 32 — Match 84', ko: '2026-07-02T19:00:00Z' },
+  { round: 7, label: 'Round of 32 — Match 83', ko: '2026-07-02T23:00:00Z' },
+  { round: 7, label: 'Round of 32 — Match 85', ko: '2026-07-03T03:00:00Z' },
+  { round: 7, label: 'Round of 32 — Match 88', ko: '2026-07-03T18:00:00Z' },
+  { round: 7, label: 'Round of 32 — Match 86', ko: '2026-07-03T22:00:00Z' },
+  {
+    round: 7,
+    label: 'Round of 32 — Match 87',
+    ko: '2026-07-04T01:30:00Z',
+    predicted: true,
+    home: 'Colombia',
+    away: 'Ghana'
+  },
+
+  // ── Round of 16 (round 8) ──────────────────────────────────────────────
+  { round: 8, label: 'Round of 16 — Match 90', ko: '2026-07-04T17:00:00Z' },
+  { round: 8, label: 'Round of 16 — Match 89', ko: '2026-07-04T21:00:00Z' },
+  { round: 8, label: 'Round of 16 — Match 91', ko: '2026-07-05T20:00:00Z' },
+  { round: 8, label: 'Round of 16 — Match 92', ko: '2026-07-06T00:00:00Z' },
+  { round: 8, label: 'Round of 16 — Match 93', ko: '2026-07-06T19:00:00Z' },
+  { round: 8, label: 'Round of 16 — Match 94', ko: '2026-07-07T00:00:00Z' },
+  { round: 8, label: 'Round of 16 — Match 95', ko: '2026-07-07T16:00:00Z' },
+  {
+    round: 8,
+    label: 'Round of 16 — Match 96',
+    ko: '2026-07-07T20:00:00Z',
+    predicted: true
+  },
+
+  // ── Quarter-finals (round 9) ───────────────────────────────────────────
+  { round: 9, label: 'Quarter-final — Match 97', ko: '2026-07-09T20:00:00Z' },
+  { round: 9, label: 'Quarter-final — Match 98', ko: '2026-07-10T19:00:00Z' },
+  { round: 9, label: 'Quarter-final — Match 99', ko: '2026-07-11T21:00:00Z' },
+  {
+    round: 9,
+    label: 'Quarter-final — Match 100',
+    ko: '2026-07-12T01:00:00Z',
+    predicted: true
+  },
+
+  // ── Semi-finals (round 10) ─────────────────────────────────────────────
+  { round: 10, label: 'Semi-final — Match 101', ko: '2026-07-14T19:00:00Z' },
+  {
+    round: 10,
+    label: 'Semi-final — Match 102',
+    ko: '2026-07-15T19:00:00Z',
+    predicted: true
+  },
+
+  // ── Final (round 11) ───────────────────────────────────────────────────
+  {
+    round: 11,
+    label: 'Final',
+    ko: '2026-07-19T19:00:00Z',
+    predicted: true
+  }
+];
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  if (searchParams.get('secret') !== process.env.WC_SEED_SECRET) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    // Guard: don't clobber existing fixtures (and the FK from picks would block
+    // a delete anyway once predictions exist). Seed only into an empty table.
+    const { rows: existing } = await sql.query<{ count: string }>(
+      `SELECT COUNT(*) AS count FROM wc_knockout_fixtures`
+    );
+    if (Number(existing[0]?.count) > 0) {
+      return Response.json(
+        {
+          error:
+            'wc_knockout_fixtures is not empty — refusing to re-seed. Edit fixtures via the admin editor instead.'
+        },
+        { status: 409 }
+      );
+    }
+
+    for (const f of KO_FIXTURES) {
+      await sql.query(
+        `INSERT INTO wc_knockout_fixtures
+           (round_number, match_label, home_team_name, away_team_name, kickoff_time, is_predicted)
+         VALUES ($1, $2, $3, $4, $5, $6)`,
+        [
+          f.round,
+          f.label,
+          f.home ?? null,
+          f.away ?? null,
+          f.ko,
+          f.predicted ?? false
+        ]
+      );
+    }
+
+    return Response.json({
+      seeded: true,
+      fixtures: KO_FIXTURES.length,
+      predicted: KO_FIXTURES.filter((f) => f.predicted).length
+    });
+  } catch (error) {
+    console.error('WC knockout seed error:', error);
+    return Response.json(
+      { error: error instanceof Error ? error.message : 'Seed failed' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/wc/knockout/standings/route.ts
+++ b/app/api/wc/knockout/standings/route.ts
@@ -1,0 +1,55 @@
+import { auth } from '@/lib/auth';
+import { sql } from '@vercel/postgres';
+import { WC_LEAGUES } from '@/lib/wc-constants';
+import { WcKnockoutStanding } from '@/lib/wc-definitions';
+
+// GET /api/wc/knockout/standings?league_id=
+// Cumulative knockout points per player for a game. Visible to any member of
+// that game (players and spectators alike). Only players who have made at least
+// one prediction appear; test accounts are excluded.
+export async function GET(request: Request) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const userId = session.user.id;
+
+  const leagueId = Number(new URL(request.url).searchParams.get('league_id'));
+  if (!Number.isInteger(leagueId) || !WC_LEAGUES[leagueId]) {
+    return Response.json({ error: 'Invalid league_id' }, { status: 400 });
+  }
+
+  const member = await sql.query(
+    `SELECT 1 FROM user_leagues WHERE user_id = $1 AND league_id = $2 LIMIT 1`,
+    [userId, leagueId]
+  );
+  if (!member.rows.length) {
+    return Response.json(
+      { error: 'Not a member of this league' },
+      { status: 403 }
+    );
+  }
+
+  try {
+    const { rows } = await sql.query<WcKnockoutStanding>(
+      `SELECT
+        kp.user_id,
+        COALESCE(u.user_name, u.name, u.email) AS user_name,
+        SUM(COALESCE(kp.points, 0))::int AS points
+      FROM wc_knockout_picks kp
+      JOIN users u ON u.id = kp.user_id
+      WHERE kp.league_id = $1
+        AND u.test_user IS NOT TRUE
+      GROUP BY kp.user_id, u.user_name, u.name, u.email
+      ORDER BY points DESC, user_name ASC`,
+      [leagueId]
+    );
+    return Response.json(rows);
+  } catch (error) {
+    console.error('Error fetching WC knockout standings:', error);
+    return Response.json(
+      { error: 'Failed to fetch standings' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/wc/knockout/standings/route.ts
+++ b/app/api/wc/knockout/standings/route.ts
@@ -31,16 +31,30 @@ export async function GET(request: Request) {
   }
 
   try {
+    // Roster = anyone who has made a knockout pick in this league, plus the
+    // league's group-stage survivors (so the players who are "in" the game show
+    // at 0 points before they've predicted). For knockout-only games there are
+    // no group picks, so the roster is just the predictors.
     const { rows } = await sql.query<WcKnockoutStanding>(
-      `SELECT
-        kp.user_id,
+      `WITH roster AS (
+        SELECT DISTINCT user_id FROM wc_knockout_picks WHERE league_id = $1
+        UNION
+        SELECT user_id FROM wc_picks
+          WHERE league_id = $1 AND round_number BETWEEN 1 AND 6
+          GROUP BY user_id
+          HAVING COUNT(*) FILTER (WHERE is_correct = true) = 6
+             AND COUNT(*) FILTER (WHERE is_correct = false) = 0
+      )
+      SELECT
+        r.user_id,
         COALESCE(u.user_name, u.name, u.email) AS user_name,
-        SUM(COALESCE(kp.points, 0))::int AS points
-      FROM wc_knockout_picks kp
-      JOIN users u ON u.id = kp.user_id
-      WHERE kp.league_id = $1
-        AND u.test_user IS NOT TRUE
-      GROUP BY kp.user_id, u.user_name, u.name, u.email
+        COALESCE(SUM(kp.points), 0)::int AS points
+      FROM roster r
+      JOIN users u ON u.id = r.user_id
+      LEFT JOIN wc_knockout_picks kp
+        ON kp.user_id = r.user_id AND kp.league_id = $1
+      WHERE u.test_user IS NOT TRUE
+      GROUP BY r.user_id, u.user_name, u.name, u.email
       ORDER BY points DESC, user_name ASC`,
       [leagueId]
     );

--- a/app/api/wc/seed/route.ts
+++ b/app/api/wc/seed/route.ts
@@ -1,68 +1,5 @@
 import { sql } from '@vercel/postgres';
-
-// All times in UTC (BST − 1hr)
-const TEAMS = [
-  // Group A
-  { name: 'Mexico',                  short_name: 'MEX', group_name: 'A' },
-  { name: 'South Africa',            short_name: 'RSA', group_name: 'A' },
-  { name: 'South Korea',             short_name: 'KOR', group_name: 'A' },
-  { name: 'Czechia',                 short_name: 'CZE', group_name: 'A' },
-  // Group B
-  { name: 'Canada',                  short_name: 'CAN', group_name: 'B' },
-  { name: 'Bosnia and Herzegovina',  short_name: 'BIH', group_name: 'B' },
-  { name: 'Qatar',                   short_name: 'QAT', group_name: 'B' },
-  { name: 'Switzerland',             short_name: 'SUI', group_name: 'B' },
-  // Group C
-  { name: 'Brazil',                  short_name: 'BRA', group_name: 'C' },
-  { name: 'Morocco',                 short_name: 'MAR', group_name: 'C' },
-  { name: 'Haiti',                   short_name: 'HAI', group_name: 'C' },
-  { name: 'Scotland',                short_name: 'SCO', group_name: 'C' },
-  // Group D
-  { name: 'USA',                     short_name: 'USA', group_name: 'D' },
-  { name: 'Paraguay',                short_name: 'PAR', group_name: 'D' },
-  { name: 'Australia',               short_name: 'AUS', group_name: 'D' },
-  { name: 'Türkiye',                 short_name: 'TUR', group_name: 'D' },
-  // Group E
-  { name: 'Germany',                 short_name: 'GER', group_name: 'E' },
-  { name: 'Curaçao',                 short_name: 'CUW', group_name: 'E' },
-  { name: 'Ivory Coast',             short_name: 'CIV', group_name: 'E' },
-  { name: 'Ecuador',                 short_name: 'ECU', group_name: 'E' },
-  // Group F
-  { name: 'Netherlands',             short_name: 'NED', group_name: 'F' },
-  { name: 'Japan',                   short_name: 'JPN', group_name: 'F' },
-  { name: 'Sweden',                  short_name: 'SWE', group_name: 'F' },
-  { name: 'Tunisia',                 short_name: 'TUN', group_name: 'F' },
-  // Group G
-  { name: 'Belgium',                 short_name: 'BEL', group_name: 'G' },
-  { name: 'Egypt',                   short_name: 'EGY', group_name: 'G' },
-  { name: 'Iran',                    short_name: 'IRN', group_name: 'G' },
-  { name: 'New Zealand',             short_name: 'NZL', group_name: 'G' },
-  // Group H
-  { name: 'Spain',                   short_name: 'ESP', group_name: 'H' },
-  { name: 'Cape Verde',              short_name: 'CPV', group_name: 'H' },
-  { name: 'Saudi Arabia',            short_name: 'KSA', group_name: 'H' },
-  { name: 'Uruguay',                 short_name: 'URU', group_name: 'H' },
-  // Group I
-  { name: 'France',                  short_name: 'FRA', group_name: 'I' },
-  { name: 'Senegal',                 short_name: 'SEN', group_name: 'I' },
-  { name: 'Iraq',                    short_name: 'IRQ', group_name: 'I' },
-  { name: 'Norway',                  short_name: 'NOR', group_name: 'I' },
-  // Group J
-  { name: 'Argentina',               short_name: 'ARG', group_name: 'J' },
-  { name: 'Algeria',                 short_name: 'ALG', group_name: 'J' },
-  { name: 'Austria',                 short_name: 'AUT', group_name: 'J' },
-  { name: 'Jordan',                  short_name: 'JOR', group_name: 'J' },
-  // Group K
-  { name: 'Portugal',                short_name: 'POR', group_name: 'K' },
-  { name: 'DR Congo',                short_name: 'COD', group_name: 'K' },
-  { name: 'Colombia',                short_name: 'COL', group_name: 'K' },
-  { name: 'Uzbekistan',              short_name: 'UZB', group_name: 'K' },
-  // Group L
-  { name: 'England',                 short_name: 'ENG', group_name: 'L' },
-  { name: 'Croatia',                 short_name: 'CRO', group_name: 'L' },
-  { name: 'Ghana',                   short_name: 'GHA', group_name: 'L' },
-  { name: 'Panama',                  short_name: 'PAN', group_name: 'L' },
-];
+import { WC_TEAMS } from '@/lib/wc-constants';
 
 // round_number maps to the 6 LPS game rounds:
 //   1 = Groups A–F Matchday 1  |  2 = Groups G–L Matchday 1
@@ -70,88 +7,520 @@ const TEAMS = [
 //   5 = Groups A–F Matchday 3  |  6 = Groups G–L Matchday 3
 const FIXTURES = [
   // ── ROUND 1: Groups A–F, Matchday 1 ──────────────────────────────────
-  { round: 1, group: 'A', home: 'Mexico',                 away: 'South Africa',           ko: '2026-06-11T19:00:00Z' },
-  { round: 1, group: 'A', home: 'South Korea',            away: 'Czechia',                ko: '2026-06-12T02:00:00Z' },
-  { round: 1, group: 'B', home: 'Canada',                 away: 'Bosnia and Herzegovina', ko: '2026-06-12T19:00:00Z' },
-  { round: 1, group: 'B', home: 'Qatar',                  away: 'Switzerland',            ko: '2026-06-13T19:00:00Z' },
-  { round: 1, group: 'C', home: 'Brazil',                 away: 'Morocco',                ko: '2026-06-13T22:00:00Z' },
-  { round: 1, group: 'C', home: 'Haiti',                  away: 'Scotland',               ko: '2026-06-14T01:00:00Z' },
-  { round: 1, group: 'D', home: 'USA',                    away: 'Paraguay',               ko: '2026-06-13T01:00:00Z' },
-  { round: 1, group: 'D', home: 'Australia',              away: 'Türkiye',                ko: '2026-06-14T04:00:00Z' },
-  { round: 1, group: 'E', home: 'Germany',                away: 'Curaçao',                ko: '2026-06-14T17:00:00Z' },
-  { round: 1, group: 'E', home: 'Ivory Coast',            away: 'Ecuador',                ko: '2026-06-14T23:00:00Z' },
-  { round: 1, group: 'F', home: 'Netherlands',            away: 'Japan',                  ko: '2026-06-14T20:00:00Z' },
-  { round: 1, group: 'F', home: 'Sweden',                 away: 'Tunisia',                ko: '2026-06-15T02:00:00Z' },
+  {
+    round: 1,
+    group: 'A',
+    home: 'Mexico',
+    away: 'South Africa',
+    ko: '2026-06-11T19:00:00Z'
+  },
+  {
+    round: 1,
+    group: 'A',
+    home: 'South Korea',
+    away: 'Czechia',
+    ko: '2026-06-12T02:00:00Z'
+  },
+  {
+    round: 1,
+    group: 'B',
+    home: 'Canada',
+    away: 'Bosnia and Herzegovina',
+    ko: '2026-06-12T19:00:00Z'
+  },
+  {
+    round: 1,
+    group: 'B',
+    home: 'Qatar',
+    away: 'Switzerland',
+    ko: '2026-06-13T19:00:00Z'
+  },
+  {
+    round: 1,
+    group: 'C',
+    home: 'Brazil',
+    away: 'Morocco',
+    ko: '2026-06-13T22:00:00Z'
+  },
+  {
+    round: 1,
+    group: 'C',
+    home: 'Haiti',
+    away: 'Scotland',
+    ko: '2026-06-14T01:00:00Z'
+  },
+  {
+    round: 1,
+    group: 'D',
+    home: 'USA',
+    away: 'Paraguay',
+    ko: '2026-06-13T01:00:00Z'
+  },
+  {
+    round: 1,
+    group: 'D',
+    home: 'Australia',
+    away: 'Türkiye',
+    ko: '2026-06-14T04:00:00Z'
+  },
+  {
+    round: 1,
+    group: 'E',
+    home: 'Germany',
+    away: 'Curaçao',
+    ko: '2026-06-14T17:00:00Z'
+  },
+  {
+    round: 1,
+    group: 'E',
+    home: 'Ivory Coast',
+    away: 'Ecuador',
+    ko: '2026-06-14T23:00:00Z'
+  },
+  {
+    round: 1,
+    group: 'F',
+    home: 'Netherlands',
+    away: 'Japan',
+    ko: '2026-06-14T20:00:00Z'
+  },
+  {
+    round: 1,
+    group: 'F',
+    home: 'Sweden',
+    away: 'Tunisia',
+    ko: '2026-06-15T02:00:00Z'
+  },
 
   // ── ROUND 2: Groups G–L, Matchday 1 ──────────────────────────────────
-  { round: 2, group: 'G', home: 'Belgium',                away: 'Egypt',                  ko: '2026-06-15T19:00:00Z' },
-  { round: 2, group: 'G', home: 'Iran',                   away: 'New Zealand',            ko: '2026-06-16T01:00:00Z' },
-  { round: 2, group: 'H', home: 'Spain',                  away: 'Cape Verde',             ko: '2026-06-15T16:00:00Z' },
-  { round: 2, group: 'H', home: 'Saudi Arabia',           away: 'Uruguay',                ko: '2026-06-15T22:00:00Z' },
-  { round: 2, group: 'I', home: 'France',                 away: 'Senegal',                ko: '2026-06-16T19:00:00Z' },
-  { round: 2, group: 'I', home: 'Iraq',                   away: 'Norway',                 ko: '2026-06-16T22:00:00Z' },
-  { round: 2, group: 'J', home: 'Argentina',              away: 'Algeria',                ko: '2026-06-17T01:00:00Z' },
-  { round: 2, group: 'J', home: 'Austria',                away: 'Jordan',                 ko: '2026-06-17T04:00:00Z' },
-  { round: 2, group: 'K', home: 'Portugal',               away: 'DR Congo',               ko: '2026-06-17T17:00:00Z' },
-  { round: 2, group: 'K', home: 'Uzbekistan',             away: 'Colombia',               ko: '2026-06-18T02:00:00Z' },
-  { round: 2, group: 'L', home: 'England',                away: 'Croatia',                ko: '2026-06-17T20:00:00Z' },
-  { round: 2, group: 'L', home: 'Ghana',                  away: 'Panama',                 ko: '2026-06-17T23:00:00Z' },
+  {
+    round: 2,
+    group: 'G',
+    home: 'Belgium',
+    away: 'Egypt',
+    ko: '2026-06-15T19:00:00Z'
+  },
+  {
+    round: 2,
+    group: 'G',
+    home: 'Iran',
+    away: 'New Zealand',
+    ko: '2026-06-16T01:00:00Z'
+  },
+  {
+    round: 2,
+    group: 'H',
+    home: 'Spain',
+    away: 'Cape Verde',
+    ko: '2026-06-15T16:00:00Z'
+  },
+  {
+    round: 2,
+    group: 'H',
+    home: 'Saudi Arabia',
+    away: 'Uruguay',
+    ko: '2026-06-15T22:00:00Z'
+  },
+  {
+    round: 2,
+    group: 'I',
+    home: 'France',
+    away: 'Senegal',
+    ko: '2026-06-16T19:00:00Z'
+  },
+  {
+    round: 2,
+    group: 'I',
+    home: 'Iraq',
+    away: 'Norway',
+    ko: '2026-06-16T22:00:00Z'
+  },
+  {
+    round: 2,
+    group: 'J',
+    home: 'Argentina',
+    away: 'Algeria',
+    ko: '2026-06-17T01:00:00Z'
+  },
+  {
+    round: 2,
+    group: 'J',
+    home: 'Austria',
+    away: 'Jordan',
+    ko: '2026-06-17T04:00:00Z'
+  },
+  {
+    round: 2,
+    group: 'K',
+    home: 'Portugal',
+    away: 'DR Congo',
+    ko: '2026-06-17T17:00:00Z'
+  },
+  {
+    round: 2,
+    group: 'K',
+    home: 'Uzbekistan',
+    away: 'Colombia',
+    ko: '2026-06-18T02:00:00Z'
+  },
+  {
+    round: 2,
+    group: 'L',
+    home: 'England',
+    away: 'Croatia',
+    ko: '2026-06-17T20:00:00Z'
+  },
+  {
+    round: 2,
+    group: 'L',
+    home: 'Ghana',
+    away: 'Panama',
+    ko: '2026-06-17T23:00:00Z'
+  },
 
   // ── ROUND 3: Groups A–F, Matchday 2 ──────────────────────────────────
-  { round: 3, group: 'A', home: 'Czechia',                away: 'South Africa',           ko: '2026-06-18T16:00:00Z' },
-  { round: 3, group: 'A', home: 'Mexico',                 away: 'South Korea',            ko: '2026-06-19T01:00:00Z' },
-  { round: 3, group: 'B', home: 'Switzerland',            away: 'Bosnia and Herzegovina', ko: '2026-06-18T19:00:00Z' },
-  { round: 3, group: 'B', home: 'Canada',                 away: 'Qatar',                  ko: '2026-06-18T22:00:00Z' },
-  { round: 3, group: 'C', home: 'Scotland',               away: 'Morocco',                ko: '2026-06-19T22:00:00Z' },
-  { round: 3, group: 'C', home: 'Brazil',                 away: 'Haiti',                  ko: '2026-06-20T00:30:00Z' },
-  { round: 3, group: 'D', home: 'USA',                    away: 'Australia',              ko: '2026-06-19T19:00:00Z' },
-  { round: 3, group: 'D', home: 'Türkiye',                away: 'Paraguay',               ko: '2026-06-20T03:00:00Z' },
-  { round: 3, group: 'E', home: 'Germany',                away: 'Ivory Coast',            ko: '2026-06-20T20:00:00Z' },
-  { round: 3, group: 'E', home: 'Ecuador',                away: 'Curaçao',                ko: '2026-06-21T00:00:00Z' },
-  { round: 3, group: 'F', home: 'Netherlands',            away: 'Sweden',                 ko: '2026-06-20T17:00:00Z' },
-  { round: 3, group: 'F', home: 'Tunisia',                away: 'Japan',                  ko: '2026-06-21T04:00:00Z' },
+  {
+    round: 3,
+    group: 'A',
+    home: 'Czechia',
+    away: 'South Africa',
+    ko: '2026-06-18T16:00:00Z'
+  },
+  {
+    round: 3,
+    group: 'A',
+    home: 'Mexico',
+    away: 'South Korea',
+    ko: '2026-06-19T01:00:00Z'
+  },
+  {
+    round: 3,
+    group: 'B',
+    home: 'Switzerland',
+    away: 'Bosnia and Herzegovina',
+    ko: '2026-06-18T19:00:00Z'
+  },
+  {
+    round: 3,
+    group: 'B',
+    home: 'Canada',
+    away: 'Qatar',
+    ko: '2026-06-18T22:00:00Z'
+  },
+  {
+    round: 3,
+    group: 'C',
+    home: 'Scotland',
+    away: 'Morocco',
+    ko: '2026-06-19T22:00:00Z'
+  },
+  {
+    round: 3,
+    group: 'C',
+    home: 'Brazil',
+    away: 'Haiti',
+    ko: '2026-06-20T00:30:00Z'
+  },
+  {
+    round: 3,
+    group: 'D',
+    home: 'USA',
+    away: 'Australia',
+    ko: '2026-06-19T19:00:00Z'
+  },
+  {
+    round: 3,
+    group: 'D',
+    home: 'Türkiye',
+    away: 'Paraguay',
+    ko: '2026-06-20T03:00:00Z'
+  },
+  {
+    round: 3,
+    group: 'E',
+    home: 'Germany',
+    away: 'Ivory Coast',
+    ko: '2026-06-20T20:00:00Z'
+  },
+  {
+    round: 3,
+    group: 'E',
+    home: 'Ecuador',
+    away: 'Curaçao',
+    ko: '2026-06-21T00:00:00Z'
+  },
+  {
+    round: 3,
+    group: 'F',
+    home: 'Netherlands',
+    away: 'Sweden',
+    ko: '2026-06-20T17:00:00Z'
+  },
+  {
+    round: 3,
+    group: 'F',
+    home: 'Tunisia',
+    away: 'Japan',
+    ko: '2026-06-21T04:00:00Z'
+  },
 
   // ── ROUND 4: Groups G–L, Matchday 2 ──────────────────────────────────
-  { round: 4, group: 'G', home: 'Belgium',                away: 'Iran',                   ko: '2026-06-21T19:00:00Z' },
-  { round: 4, group: 'G', home: 'New Zealand',            away: 'Egypt',                  ko: '2026-06-22T01:00:00Z' },
-  { round: 4, group: 'H', home: 'Spain',                  away: 'Saudi Arabia',           ko: '2026-06-21T16:00:00Z' },
-  { round: 4, group: 'H', home: 'Uruguay',                away: 'Cape Verde',             ko: '2026-06-21T22:00:00Z' },
-  { round: 4, group: 'I', home: 'France',                 away: 'Iraq',                   ko: '2026-06-22T21:00:00Z' },
-  { round: 4, group: 'I', home: 'Norway',                 away: 'Senegal',                ko: '2026-06-23T00:00:00Z' },
-  { round: 4, group: 'J', home: 'Argentina',              away: 'Austria',                ko: '2026-06-22T17:00:00Z' },
-  { round: 4, group: 'J', home: 'Jordan',                 away: 'Algeria',                ko: '2026-06-23T03:00:00Z' },
-  { round: 4, group: 'K', home: 'Portugal',               away: 'Uzbekistan',             ko: '2026-06-23T17:00:00Z' },
-  { round: 4, group: 'K', home: 'Colombia',               away: 'DR Congo',               ko: '2026-06-24T02:00:00Z' },
-  { round: 4, group: 'L', home: 'England',                away: 'Ghana',                  ko: '2026-06-23T20:00:00Z' },
-  { round: 4, group: 'L', home: 'Panama',                 away: 'Croatia',                ko: '2026-06-23T23:00:00Z' },
+  {
+    round: 4,
+    group: 'G',
+    home: 'Belgium',
+    away: 'Iran',
+    ko: '2026-06-21T19:00:00Z'
+  },
+  {
+    round: 4,
+    group: 'G',
+    home: 'New Zealand',
+    away: 'Egypt',
+    ko: '2026-06-22T01:00:00Z'
+  },
+  {
+    round: 4,
+    group: 'H',
+    home: 'Spain',
+    away: 'Saudi Arabia',
+    ko: '2026-06-21T16:00:00Z'
+  },
+  {
+    round: 4,
+    group: 'H',
+    home: 'Uruguay',
+    away: 'Cape Verde',
+    ko: '2026-06-21T22:00:00Z'
+  },
+  {
+    round: 4,
+    group: 'I',
+    home: 'France',
+    away: 'Iraq',
+    ko: '2026-06-22T21:00:00Z'
+  },
+  {
+    round: 4,
+    group: 'I',
+    home: 'Norway',
+    away: 'Senegal',
+    ko: '2026-06-23T00:00:00Z'
+  },
+  {
+    round: 4,
+    group: 'J',
+    home: 'Argentina',
+    away: 'Austria',
+    ko: '2026-06-22T17:00:00Z'
+  },
+  {
+    round: 4,
+    group: 'J',
+    home: 'Jordan',
+    away: 'Algeria',
+    ko: '2026-06-23T03:00:00Z'
+  },
+  {
+    round: 4,
+    group: 'K',
+    home: 'Portugal',
+    away: 'Uzbekistan',
+    ko: '2026-06-23T17:00:00Z'
+  },
+  {
+    round: 4,
+    group: 'K',
+    home: 'Colombia',
+    away: 'DR Congo',
+    ko: '2026-06-24T02:00:00Z'
+  },
+  {
+    round: 4,
+    group: 'L',
+    home: 'England',
+    away: 'Ghana',
+    ko: '2026-06-23T20:00:00Z'
+  },
+  {
+    round: 4,
+    group: 'L',
+    home: 'Panama',
+    away: 'Croatia',
+    ko: '2026-06-23T23:00:00Z'
+  },
 
   // ── ROUND 5: Groups A–F, Matchday 3 ──────────────────────────────────
-  { round: 5, group: 'A', home: 'South Africa',           away: 'South Korea',            ko: '2026-06-25T01:00:00Z' },
-  { round: 5, group: 'A', home: 'Czechia',                away: 'Mexico',                 ko: '2026-06-25T01:00:00Z' },
-  { round: 5, group: 'B', home: 'Switzerland',            away: 'Canada',                 ko: '2026-06-24T19:00:00Z' },
-  { round: 5, group: 'B', home: 'Bosnia and Herzegovina', away: 'Qatar',                  ko: '2026-06-24T19:00:00Z' },
-  { round: 5, group: 'C', home: 'Morocco',                away: 'Haiti',                  ko: '2026-06-24T22:00:00Z' },
-  { round: 5, group: 'C', home: 'Scotland',               away: 'Brazil',                 ko: '2026-06-24T22:00:00Z' },
-  { round: 5, group: 'D', home: 'Türkiye',                away: 'USA',                    ko: '2026-06-26T02:00:00Z' },
-  { round: 5, group: 'D', home: 'Paraguay',               away: 'Australia',              ko: '2026-06-26T02:00:00Z' },
-  { round: 5, group: 'E', home: 'Curaçao',                away: 'Ivory Coast',            ko: '2026-06-25T20:00:00Z' },
-  { round: 5, group: 'E', home: 'Ecuador',                away: 'Germany',                ko: '2026-06-25T20:00:00Z' },
-  { round: 5, group: 'F', home: 'Tunisia',                away: 'Netherlands',            ko: '2026-06-25T23:00:00Z' },
-  { round: 5, group: 'F', home: 'Japan',                  away: 'Sweden',                 ko: '2026-06-25T23:00:00Z' },
+  {
+    round: 5,
+    group: 'A',
+    home: 'South Africa',
+    away: 'South Korea',
+    ko: '2026-06-25T01:00:00Z'
+  },
+  {
+    round: 5,
+    group: 'A',
+    home: 'Czechia',
+    away: 'Mexico',
+    ko: '2026-06-25T01:00:00Z'
+  },
+  {
+    round: 5,
+    group: 'B',
+    home: 'Switzerland',
+    away: 'Canada',
+    ko: '2026-06-24T19:00:00Z'
+  },
+  {
+    round: 5,
+    group: 'B',
+    home: 'Bosnia and Herzegovina',
+    away: 'Qatar',
+    ko: '2026-06-24T19:00:00Z'
+  },
+  {
+    round: 5,
+    group: 'C',
+    home: 'Morocco',
+    away: 'Haiti',
+    ko: '2026-06-24T22:00:00Z'
+  },
+  {
+    round: 5,
+    group: 'C',
+    home: 'Scotland',
+    away: 'Brazil',
+    ko: '2026-06-24T22:00:00Z'
+  },
+  {
+    round: 5,
+    group: 'D',
+    home: 'Türkiye',
+    away: 'USA',
+    ko: '2026-06-26T02:00:00Z'
+  },
+  {
+    round: 5,
+    group: 'D',
+    home: 'Paraguay',
+    away: 'Australia',
+    ko: '2026-06-26T02:00:00Z'
+  },
+  {
+    round: 5,
+    group: 'E',
+    home: 'Curaçao',
+    away: 'Ivory Coast',
+    ko: '2026-06-25T20:00:00Z'
+  },
+  {
+    round: 5,
+    group: 'E',
+    home: 'Ecuador',
+    away: 'Germany',
+    ko: '2026-06-25T20:00:00Z'
+  },
+  {
+    round: 5,
+    group: 'F',
+    home: 'Tunisia',
+    away: 'Netherlands',
+    ko: '2026-06-25T23:00:00Z'
+  },
+  {
+    round: 5,
+    group: 'F',
+    home: 'Japan',
+    away: 'Sweden',
+    ko: '2026-06-25T23:00:00Z'
+  },
 
   // ── ROUND 6: Groups G–L, Matchday 3 ──────────────────────────────────
-  { round: 6, group: 'G', home: 'New Zealand',            away: 'Belgium',                ko: '2026-06-27T03:00:00Z' },
-  { round: 6, group: 'G', home: 'Egypt',                  away: 'Iran',                   ko: '2026-06-27T03:00:00Z' },
-  { round: 6, group: 'H', home: 'Cape Verde',             away: 'Saudi Arabia',           ko: '2026-06-27T00:00:00Z' },
-  { round: 6, group: 'H', home: 'Uruguay',                away: 'Spain',                  ko: '2026-06-27T00:00:00Z' },
-  { round: 6, group: 'I', home: 'Norway',                 away: 'France',                 ko: '2026-06-26T19:00:00Z' },
-  { round: 6, group: 'I', home: 'Senegal',                away: 'Iraq',                   ko: '2026-06-26T19:00:00Z' },
-  { round: 6, group: 'J', home: 'Algeria',                away: 'Austria',                ko: '2026-06-28T02:00:00Z' },
-  { round: 6, group: 'J', home: 'Jordan',                 away: 'Argentina',              ko: '2026-06-28T02:00:00Z' },
-  { round: 6, group: 'K', home: 'Colombia',               away: 'Portugal',               ko: '2026-06-27T23:30:00Z' },
-  { round: 6, group: 'K', home: 'DR Congo',               away: 'Uzbekistan',             ko: '2026-06-27T23:30:00Z' },
-  { round: 6, group: 'L', home: 'Panama',                 away: 'England',                ko: '2026-06-27T21:00:00Z' },
-  { round: 6, group: 'L', home: 'Croatia',                away: 'Ghana',                  ko: '2026-06-27T21:00:00Z' },
+  {
+    round: 6,
+    group: 'G',
+    home: 'New Zealand',
+    away: 'Belgium',
+    ko: '2026-06-27T03:00:00Z'
+  },
+  {
+    round: 6,
+    group: 'G',
+    home: 'Egypt',
+    away: 'Iran',
+    ko: '2026-06-27T03:00:00Z'
+  },
+  {
+    round: 6,
+    group: 'H',
+    home: 'Cape Verde',
+    away: 'Saudi Arabia',
+    ko: '2026-06-27T00:00:00Z'
+  },
+  {
+    round: 6,
+    group: 'H',
+    home: 'Uruguay',
+    away: 'Spain',
+    ko: '2026-06-27T00:00:00Z'
+  },
+  {
+    round: 6,
+    group: 'I',
+    home: 'Norway',
+    away: 'France',
+    ko: '2026-06-26T19:00:00Z'
+  },
+  {
+    round: 6,
+    group: 'I',
+    home: 'Senegal',
+    away: 'Iraq',
+    ko: '2026-06-26T19:00:00Z'
+  },
+  {
+    round: 6,
+    group: 'J',
+    home: 'Algeria',
+    away: 'Austria',
+    ko: '2026-06-28T02:00:00Z'
+  },
+  {
+    round: 6,
+    group: 'J',
+    home: 'Jordan',
+    away: 'Argentina',
+    ko: '2026-06-28T02:00:00Z'
+  },
+  {
+    round: 6,
+    group: 'K',
+    home: 'Colombia',
+    away: 'Portugal',
+    ko: '2026-06-27T23:30:00Z'
+  },
+  {
+    round: 6,
+    group: 'K',
+    home: 'DR Congo',
+    away: 'Uzbekistan',
+    ko: '2026-06-27T23:30:00Z'
+  },
+  {
+    round: 6,
+    group: 'L',
+    home: 'Panama',
+    away: 'England',
+    ko: '2026-06-27T21:00:00Z'
+  },
+  {
+    round: 6,
+    group: 'L',
+    home: 'Croatia',
+    away: 'Ghana',
+    ko: '2026-06-27T21:00:00Z'
+  }
 ];
 
 export async function GET(request: Request) {
@@ -166,7 +535,7 @@ export async function GET(request: Request) {
     await sql.query(`DELETE FROM wc_teams`);
 
     // Insert teams
-    for (const team of TEAMS) {
+    for (const team of WC_TEAMS) {
       await sql.query(
         `INSERT INTO wc_teams (name, short_name, group_name) VALUES ($1, $2, $3)`,
         [team.name, team.short_name, team.group_name]
@@ -177,7 +546,9 @@ export async function GET(request: Request) {
     const { rows: teamRows } = await sql.query<{ id: number; name: string }>(
       `SELECT id, name FROM wc_teams`
     );
-    const teamIdByName = Object.fromEntries(teamRows.map((r) => [r.name, r.id]));
+    const teamIdByName = Object.fromEntries(
+      teamRows.map((r) => [r.name, r.id])
+    );
 
     // Verify all fixture team names resolve before inserting
     for (const f of FIXTURES) {
@@ -198,7 +569,7 @@ export async function GET(request: Request) {
 
     return Response.json({
       seeded: true,
-      teams: TEAMS.length,
+      teams: WC_TEAMS.length,
       fixtures: FIXTURES.length
     });
   } catch (error) {

--- a/app/hooks/useWcKnockoutFixtures.ts
+++ b/app/hooks/useWcKnockoutFixtures.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+import { WcKnockoutFixture } from '@/lib/wc-definitions';
+
+const useWcKnockoutFixtures = () => {
+  const [wcKnockoutFixtures, setWcKnockoutFixtures] = useState<
+    WcKnockoutFixture[]
+  >([]);
+  const [isLoadingWcKnockoutFixtures, setIsLoadingWcKnockoutFixtures] =
+    useState(true);
+
+  useEffect(() => {
+    async function fetchFixtures() {
+      setIsLoadingWcKnockoutFixtures(true);
+      const res = await fetch('/api/wc/knockout/fixtures');
+      if (!res.ok) {
+        setIsLoadingWcKnockoutFixtures(false);
+        return;
+      }
+      const data = await res.json();
+      setWcKnockoutFixtures(data);
+      setIsLoadingWcKnockoutFixtures(false);
+    }
+
+    fetchFixtures();
+  }, []);
+
+  return { wcKnockoutFixtures, isLoadingWcKnockoutFixtures };
+};
+
+export default useWcKnockoutFixtures;

--- a/app/hooks/useWcKnockoutPicks.ts
+++ b/app/hooks/useWcKnockoutPicks.ts
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+import { WcKnockoutPick } from '@/lib/wc-definitions';
+import { useSession } from 'next-auth/react';
+
+const useWcKnockoutPicks = ({
+  leagueId,
+  refreshTrigger
+}: {
+  leagueId: number | null;
+  refreshTrigger: number;
+}) => {
+  const [wcKnockoutPicks, setWcKnockoutPicks] = useState<WcKnockoutPick[]>([]);
+  const [isLoadingWcKnockoutPicks, setIsLoadingWcKnockoutPicks] =
+    useState(true);
+
+  const { status } = useSession();
+
+  useEffect(() => {
+    async function fetchPicks() {
+      setIsLoadingWcKnockoutPicks(true);
+      const res = await fetch(`/api/wc/knockout/picks?league_id=${leagueId}`);
+      if (!res.ok) {
+        setIsLoadingWcKnockoutPicks(false);
+        return;
+      }
+      const data = await res.json();
+      setWcKnockoutPicks(data);
+      setIsLoadingWcKnockoutPicks(false);
+    }
+
+    if (status === 'loading') return;
+
+    if (status === 'authenticated' && leagueId != null) {
+      fetchPicks();
+    } else {
+      setWcKnockoutPicks([]);
+      setIsLoadingWcKnockoutPicks(false);
+    }
+  }, [leagueId, refreshTrigger, status]);
+
+  return { wcKnockoutPicks, isLoadingWcKnockoutPicks };
+};
+
+export default useWcKnockoutPicks;

--- a/app/hooks/useWcKnockoutStandings.ts
+++ b/app/hooks/useWcKnockoutStandings.ts
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react';
+import { WcKnockoutStanding } from '@/lib/wc-definitions';
+import { useSession } from 'next-auth/react';
+
+const useWcKnockoutStandings = ({
+  leagueId,
+  refreshTrigger
+}: {
+  leagueId: number | null;
+  refreshTrigger: number;
+}) => {
+  const [wcKnockoutStandings, setWcKnockoutStandings] = useState<
+    WcKnockoutStanding[]
+  >([]);
+  const [isLoadingWcKnockoutStandings, setIsLoadingWcKnockoutStandings] =
+    useState(true);
+
+  const { status } = useSession();
+
+  useEffect(() => {
+    async function fetchStandings() {
+      setIsLoadingWcKnockoutStandings(true);
+      const res = await fetch(
+        `/api/wc/knockout/standings?league_id=${leagueId}`
+      );
+      if (!res.ok) {
+        setIsLoadingWcKnockoutStandings(false);
+        return;
+      }
+      const data = await res.json();
+      setWcKnockoutStandings(data);
+      setIsLoadingWcKnockoutStandings(false);
+    }
+
+    if (status === 'loading') return;
+
+    if (status === 'authenticated' && leagueId != null) {
+      fetchStandings();
+    } else {
+      setWcKnockoutStandings([]);
+      setIsLoadingWcKnockoutStandings(false);
+    }
+  }, [leagueId, refreshTrigger, status]);
+
+  return { wcKnockoutStandings, isLoadingWcKnockoutStandings };
+};
+
+export default useWcKnockoutStandings;

--- a/app/hooks/useWcLeagues.ts
+++ b/app/hooks/useWcLeagues.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react';
+import { WcLeagueMembership } from '@/lib/wc-definitions';
+import { useSession } from 'next-auth/react';
+
+const useWcLeagues = () => {
+  const [wcLeagues, setWcLeagues] = useState<WcLeagueMembership[]>([]);
+  const [isLoadingWcLeagues, setIsLoadingWcLeagues] = useState(true);
+
+  const { status } = useSession();
+
+  useEffect(() => {
+    async function fetchLeagues() {
+      setIsLoadingWcLeagues(true);
+      const res = await fetch('/api/wc/knockout/leagues');
+      if (!res.ok) {
+        setIsLoadingWcLeagues(false);
+        return;
+      }
+      const data = await res.json();
+      setWcLeagues(data);
+      setIsLoadingWcLeagues(false);
+    }
+
+    // Hold loading until the session resolves so we never flash an empty selector.
+    if (status === 'loading') return;
+
+    if (status === 'authenticated') {
+      fetchLeagues();
+    } else {
+      setWcLeagues([]);
+      setIsLoadingWcLeagues(false);
+    }
+  }, [status]);
+
+  return { wcLeagues, isLoadingWcLeagues };
+};
+
+export default useWcLeagues;

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -2,7 +2,7 @@ import NextAuth from 'next-auth';
 import NeonAdapter from '@auth/neon-adapter';
 import { Pool } from '@neondatabase/serverless';
 import Resend from 'next-auth/providers/resend';
-import { WC_LEAGUE_ID } from '@/lib/wc-constants';
+import { WC_LEAGUE_ID, WC_PARALLEL_LEAGUE_ID } from '@/lib/wc-constants';
 
 declare module 'next-auth' {
   interface User {
@@ -77,9 +77,13 @@ export const { handlers, auth, signIn, signOut } = NextAuth(() => {
       async createUser({ user }) {
         if (!user.id) return;
         try {
+          // Enrol into both games: the original (Game 1) and the parallel
+          // knockout-only game (Game 2). Spectator in any game they can't play.
           await pool.query(
-            'INSERT INTO user_leagues (user_id, league_id, joined_at) VALUES ($1, $2, NOW()) ON CONFLICT DO NOTHING',
-            [user.id, WC_LEAGUE_ID]
+            `INSERT INTO user_leagues (user_id, league_id, joined_at)
+             VALUES ($1, $2, NOW()), ($1, $3, NOW())
+             ON CONFLICT DO NOTHING`,
+            [user.id, WC_LEAGUE_ID, WC_PARALLEL_LEAGUE_ID]
           );
         } catch (error) {
           // Don't fail the sign-in — log so the user can be backfilled manually

--- a/lib/knockout.test.ts
+++ b/lib/knockout.test.ts
@@ -28,5 +28,7 @@ describe('computeKnockoutPoints', () => {
   it('prefers the exact-score bonus over the result points', () => {
     // Exact draw scoreline still scores 5, not 2
     expect(computeKnockoutPoints(1, 1, 1, 1)).toBe(5);
+    // Non-draw exact score still scores 5, not the 2-point result award
+    expect(computeKnockoutPoints(2, 0, 2, 0)).toBe(5);
   });
 });

--- a/lib/knockout.test.ts
+++ b/lib/knockout.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { computeKnockoutPoints } from './knockout';
+
+describe('computeKnockoutPoints', () => {
+  it('awards 5 for an exact score', () => {
+    expect(computeKnockoutPoints(2, 1, 2, 1)).toBe(5);
+    expect(computeKnockoutPoints(0, 0, 0, 0)).toBe(5);
+  });
+
+  it('awards 2 for the correct result but wrong score', () => {
+    // Predicted home win, actual home win (different scoreline)
+    expect(computeKnockoutPoints(2, 1, 3, 0)).toBe(2);
+    // Predicted away win, actual away win
+    expect(computeKnockoutPoints(0, 1, 1, 3)).toBe(2);
+    // Predicted draw, actual draw (different scoreline)
+    expect(computeKnockoutPoints(1, 1, 2, 2)).toBe(2);
+  });
+
+  it('awards 0 for the wrong result', () => {
+    // Predicted home win, actual away win
+    expect(computeKnockoutPoints(2, 1, 0, 1)).toBe(0);
+    // Predicted draw, actual home win
+    expect(computeKnockoutPoints(1, 1, 2, 1)).toBe(0);
+    // Predicted home win, actual draw
+    expect(computeKnockoutPoints(1, 0, 1, 1)).toBe(0);
+  });
+
+  it('prefers the exact-score bonus over the result points', () => {
+    // Exact draw scoreline still scores 5, not 2
+    expect(computeKnockoutPoints(1, 1, 1, 1)).toBe(5);
+  });
+});

--- a/lib/knockout.ts
+++ b/lib/knockout.ts
@@ -1,5 +1,18 @@
 import { sql } from '@vercel/postgres';
 
+// Knockout scoring: 5 for the exact score, 2 for the correct result (W/D/L),
+// 0 otherwise. Single source of the scoring rule (used by the admin result API).
+export function computeKnockoutPoints(
+  predHome: number,
+  predAway: number,
+  actHome: number,
+  actAway: number
+): 0 | 2 | 5 {
+  if (predHome === actHome && predAway === actAway) return 5;
+  if (Math.sign(predHome - predAway) === Math.sign(actHome - actAway)) return 2;
+  return 0;
+}
+
 // A user "survived" the group stage — and so may submit knockout picks in the
 // original game — iff they have a correct pick in all 6 group rounds and none
 // incorrect. (The parallel knockout game is open to everyone, so this check is

--- a/lib/knockout.ts
+++ b/lib/knockout.ts
@@ -1,0 +1,25 @@
+import { sql } from '@vercel/postgres';
+
+// A user "survived" the group stage — and so may submit knockout picks in the
+// original game — iff they have a correct pick in all 6 group rounds and none
+// incorrect. (The parallel knockout game is open to everyone, so this check is
+// only applied to non-knockout-only leagues.)
+export async function isSurvivor(
+  userId: string | number,
+  leagueId: number
+): Promise<boolean> {
+  const { rows } = await sql.query<{ correct: string; wrong: string }>(
+    `SELECT
+        COUNT(*) FILTER (WHERE is_correct = true)  AS correct,
+        COUNT(*) FILTER (WHERE is_correct = false) AS wrong
+     FROM wc_picks
+     WHERE user_id = $1
+       AND league_id = $2
+       AND round_number BETWEEN 1 AND 6`,
+    [userId, leagueId]
+  );
+
+  const row = rows[0];
+  // COUNT(...) comes back as a string (bigint) from node-postgres.
+  return !!row && Number(row.wrong) === 0 && Number(row.correct) === 6;
+}

--- a/lib/wc-constants.ts
+++ b/lib/wc-constants.ts
@@ -1,5 +1,35 @@
 export const WC_LEAGUE_ID = 3;
 
+// Parallel knockout-only game running alongside the original. Requires a matching
+// `leagues` row with this id and all users enrolled via `user_leagues` (see DB setup).
+export const WC_PARALLEL_LEAGUE_ID = 4;
+
+// Display metadata for the game selector. `knockoutOnly` games hide the Group Stage tab.
+export const WC_LEAGUES: Record<
+  number,
+  { name: string; knockoutOnly: boolean }
+> = {
+  [WC_LEAGUE_ID]: { name: 'World Cup 2026 Game 1', knockoutOnly: false },
+  [WC_PARALLEL_LEAGUE_ID]: {
+    name: 'World Cup 2026 Game 2 (Knockout only)',
+    knockoutOnly: true
+  }
+};
+
+// The knockout (score-prediction) rounds.
+export const WC_KNOCKOUT_ROUNDS = [7, 8, 9, 10, 11] as const;
+
+// Knockout picks close this long before the predicted match kicks off.
+export const KNOCKOUT_DEADLINE_OFFSET_MS = 60 * 60 * 1000; // 1 hour
+
+// A knockout round's deadline is derived from its predicted fixture's kickoff time,
+// so editing the fixture (e.g. from a phone) moves the deadline automatically.
+export function getKnockoutDeadline(kickoffTime: Date | string): Date {
+  const ko =
+    typeof kickoffTime === 'string' ? new Date(kickoffTime) : kickoffTime;
+  return new Date(ko.getTime() - KNOCKOUT_DEADLINE_OFFSET_MS);
+}
+
 export const WC_ROUND_DEADLINES: Record<number, Date> = {
   // Group stage
   1: new Date('2026-06-11T17:00:00Z'), // 6pm BST

--- a/lib/wc-constants.ts
+++ b/lib/wc-constants.ts
@@ -9,11 +9,11 @@ export const WC_ROUND_DEADLINES: Record<number, Date> = {
   5: new Date('2026-06-24T17:00:00Z'), // 6pm BST
   6: new Date('2026-06-26T17:00:00Z'),
   // Knockout stage
-  7:  new Date('2026-06-28T18:00:00Z'), // 7pm BST — Round of 32
-  8:  new Date('2026-07-04T16:00:00Z'), // 5pm BST — Round of 16
-  9:  new Date('2026-07-09T19:00:00Z'), // 8pm BST — Quarter-Finals
+  7: new Date('2026-06-28T18:00:00Z'), // 7pm BST — Round of 32
+  8: new Date('2026-07-04T16:00:00Z'), // 5pm BST — Round of 16
+  9: new Date('2026-07-09T19:00:00Z'), // 8pm BST — Quarter-Finals
   10: new Date('2026-07-14T18:00:00Z'), // 7pm BST — Semi-Finals
-  11: new Date('2026-07-19T18:00:00Z'), // 7pm BST — The Final
+  11: new Date('2026-07-19T18:00:00Z') // 7pm BST — The Final
 };
 
 export const WC_ROUND_LABELS: Record<number, string> = {
@@ -23,11 +23,11 @@ export const WC_ROUND_LABELS: Record<number, string> = {
   4: 'Round 4 — Groups G–L, Matchday 2 (21–23 Jun)',
   5: 'Round 5 — Groups A–F, Matchday 3 (24–25 Jun)',
   6: 'Round 6 — Groups G–L, Matchday 3 (26–27 Jun)',
-  7:  'Round 7 — Round of 32',
-  8:  'Round 8 — Round of 16',
-  9:  'Round 9 — Quarter-Finals',
+  7: 'Round 7 — Round of 32',
+  8: 'Round 8 — Round of 16',
+  9: 'Round 9 — Quarter-Finals',
   10: 'Round 10 — Semi-Finals',
-  11: 'Round 11 — The Final',
+  11: 'Round 11 — The Final'
 };
 
 // Short fixture description for each round (used in rules tables)
@@ -38,11 +38,11 @@ export const WC_ROUND_FIXTURE_LABELS: Record<number, string> = {
   4: 'Groups G–L, Matchday 2',
   5: 'Groups A–F, Matchday 3',
   6: 'Groups G–L, Matchday 3',
-  7:  'Round of 32',
-  8:  'Round of 16',
-  9:  'Quarter-Finals',
+  7: 'Round of 32',
+  8: 'Round of 16',
+  9: 'Quarter-Finals',
   10: 'Semi-Finals',
-  11: 'The Final 🏆',
+  11: 'The Final 🏆'
 };
 
 export const WC_ROUND_GROUPS: Record<number, string[]> = {
@@ -116,3 +116,82 @@ export const WC_TEAM_FLAGS: Record<string, string> = {
   Ghana: '🇬🇭',
   Panama: '🇵🇦'
 };
+
+// ── Single source of truth for all 48 team identities ────────────────────────
+// Consumed by the seed route and the knockout admin team-name dropdown.
+// Flags are derived from WC_TEAM_FLAGS above so the special England/Scotland
+// subdivision flag emojis live in exactly one place.
+export type WcTeamInfo = {
+  name: string;
+  short_name: string;
+  group_name: string;
+  flag: string;
+};
+
+const RAW_TEAMS: Omit<WcTeamInfo, 'flag'>[] = [
+  // Group A
+  { name: 'Mexico', short_name: 'MEX', group_name: 'A' },
+  { name: 'South Africa', short_name: 'RSA', group_name: 'A' },
+  { name: 'South Korea', short_name: 'KOR', group_name: 'A' },
+  { name: 'Czechia', short_name: 'CZE', group_name: 'A' },
+  // Group B
+  { name: 'Canada', short_name: 'CAN', group_name: 'B' },
+  { name: 'Bosnia and Herzegovina', short_name: 'BIH', group_name: 'B' },
+  { name: 'Qatar', short_name: 'QAT', group_name: 'B' },
+  { name: 'Switzerland', short_name: 'SUI', group_name: 'B' },
+  // Group C
+  { name: 'Brazil', short_name: 'BRA', group_name: 'C' },
+  { name: 'Morocco', short_name: 'MAR', group_name: 'C' },
+  { name: 'Haiti', short_name: 'HAI', group_name: 'C' },
+  { name: 'Scotland', short_name: 'SCO', group_name: 'C' },
+  // Group D
+  { name: 'USA', short_name: 'USA', group_name: 'D' },
+  { name: 'Paraguay', short_name: 'PAR', group_name: 'D' },
+  { name: 'Australia', short_name: 'AUS', group_name: 'D' },
+  { name: 'Türkiye', short_name: 'TUR', group_name: 'D' },
+  // Group E
+  { name: 'Germany', short_name: 'GER', group_name: 'E' },
+  { name: 'Curaçao', short_name: 'CUW', group_name: 'E' },
+  { name: 'Ivory Coast', short_name: 'CIV', group_name: 'E' },
+  { name: 'Ecuador', short_name: 'ECU', group_name: 'E' },
+  // Group F
+  { name: 'Netherlands', short_name: 'NED', group_name: 'F' },
+  { name: 'Japan', short_name: 'JPN', group_name: 'F' },
+  { name: 'Sweden', short_name: 'SWE', group_name: 'F' },
+  { name: 'Tunisia', short_name: 'TUN', group_name: 'F' },
+  // Group G
+  { name: 'Belgium', short_name: 'BEL', group_name: 'G' },
+  { name: 'Egypt', short_name: 'EGY', group_name: 'G' },
+  { name: 'Iran', short_name: 'IRN', group_name: 'G' },
+  { name: 'New Zealand', short_name: 'NZL', group_name: 'G' },
+  // Group H
+  { name: 'Spain', short_name: 'ESP', group_name: 'H' },
+  { name: 'Cape Verde', short_name: 'CPV', group_name: 'H' },
+  { name: 'Saudi Arabia', short_name: 'KSA', group_name: 'H' },
+  { name: 'Uruguay', short_name: 'URU', group_name: 'H' },
+  // Group I
+  { name: 'France', short_name: 'FRA', group_name: 'I' },
+  { name: 'Senegal', short_name: 'SEN', group_name: 'I' },
+  { name: 'Iraq', short_name: 'IRQ', group_name: 'I' },
+  { name: 'Norway', short_name: 'NOR', group_name: 'I' },
+  // Group J
+  { name: 'Argentina', short_name: 'ARG', group_name: 'J' },
+  { name: 'Algeria', short_name: 'ALG', group_name: 'J' },
+  { name: 'Austria', short_name: 'AUT', group_name: 'J' },
+  { name: 'Jordan', short_name: 'JOR', group_name: 'J' },
+  // Group K
+  { name: 'Portugal', short_name: 'POR', group_name: 'K' },
+  { name: 'DR Congo', short_name: 'COD', group_name: 'K' },
+  { name: 'Colombia', short_name: 'COL', group_name: 'K' },
+  { name: 'Uzbekistan', short_name: 'UZB', group_name: 'K' },
+  // Group L
+  { name: 'England', short_name: 'ENG', group_name: 'L' },
+  { name: 'Croatia', short_name: 'CRO', group_name: 'L' },
+  { name: 'Ghana', short_name: 'GHA', group_name: 'L' },
+  { name: 'Panama', short_name: 'PAN', group_name: 'L' }
+];
+
+export const WC_TEAMS: WcTeamInfo[] = RAW_TEAMS.map((t) => ({
+  ...t,
+  flag: WC_TEAM_FLAGS[t.name] ?? '🏳'
+}));

--- a/lib/wc-constants.ts
+++ b/lib/wc-constants.ts
@@ -4,12 +4,20 @@ export const WC_LEAGUE_ID = 3;
 // `leagues` row with this id and all users enrolled via `user_leagues` (see DB setup).
 export const WC_PARALLEL_LEAGUE_ID = 4;
 
-// Display metadata for the game selector. `knockoutOnly` games hide the Group Stage tab.
+// Display metadata for the game selector. `knockoutOnly` games hide the Group
+// Stage tab. `pot` is a fixed prize pool (£) for games where it isn't simply
+// £10 × current knockout entrants — e.g. Game 1's pot is the original group-stage
+// pool (18 entrants), even though only the 3 survivors play the knockout. Games
+// without a `pot` fall back to £10 × players who've predicted.
 export const WC_LEAGUES: Record<
   number,
-  { name: string; knockoutOnly: boolean }
+  { name: string; knockoutOnly: boolean; pot?: number }
 > = {
-  [WC_LEAGUE_ID]: { name: 'World Cup 2026 Game 1', knockoutOnly: false },
+  [WC_LEAGUE_ID]: {
+    name: 'World Cup 2026 Game 1',
+    knockoutOnly: false,
+    pot: 180
+  },
   [WC_PARALLEL_LEAGUE_ID]: {
     name: 'World Cup 2026 Game 2 (Knockout only)',
     knockoutOnly: true

--- a/lib/wc-constants.ts
+++ b/lib/wc-constants.ts
@@ -30,20 +30,16 @@ export function getKnockoutDeadline(kickoffTime: Date | string): Date {
   return new Date(ko.getTime() - KNOCKOUT_DEADLINE_OFFSET_MS);
 }
 
+// Group-stage deadlines only. Knockout deadlines are derived live from each
+// round's predicted fixture kickoff (see getKnockoutDeadline), so they are not
+// hardcoded here.
 export const WC_ROUND_DEADLINES: Record<number, Date> = {
-  // Group stage
   1: new Date('2026-06-11T17:00:00Z'), // 6pm BST
   2: new Date('2026-06-15T14:00:00Z'), // 3pm BST
   3: new Date('2026-06-18T14:00:00Z'),
   4: new Date('2026-06-21T14:00:00Z'),
   5: new Date('2026-06-24T17:00:00Z'), // 6pm BST
-  6: new Date('2026-06-26T17:00:00Z'),
-  // Knockout stage
-  7: new Date('2026-06-28T18:00:00Z'), // 7pm BST — Round of 32
-  8: new Date('2026-07-04T16:00:00Z'), // 5pm BST — Round of 16
-  9: new Date('2026-07-09T19:00:00Z'), // 8pm BST — Quarter-Finals
-  10: new Date('2026-07-14T18:00:00Z'), // 7pm BST — Semi-Finals
-  11: new Date('2026-07-19T18:00:00Z') // 7pm BST — The Final
+  6: new Date('2026-06-26T17:00:00Z')
 };
 
 export const WC_ROUND_LABELS: Record<number, string> = {

--- a/lib/wc-definitions.ts
+++ b/lib/wc-definitions.ts
@@ -56,3 +56,68 @@ export type WcAdminResultResponse = {
   picks_resolved: number;
   was_complete: boolean;
 };
+
+// ── Knockout stage (score-prediction phase, rounds 7–11) ─────────────────────
+
+// A knockout fixture. Team names are free-text (nullable = TBD until the bracket
+// resolves) and chosen by the admin from WC_TEAMS. Exactly one row per round has
+// is_predicted = true — the match everyone score-predicts.
+export type WcKnockoutFixture = {
+  id: number;
+  round_number: number; // 7..11
+  match_label: string; // e.g. 'R32 Match 16', 'Quarter-Final 4', 'Final'
+  home_team_name: string | null;
+  away_team_name: string | null;
+  kickoff_time: string; // ISO string
+  is_predicted: boolean;
+  home_team_score: number | null;
+  away_team_score: number | null;
+  is_complete: boolean;
+};
+
+// A user's score prediction for a round's predicted fixture.
+export type WcKnockoutPick = {
+  round_number: number;
+  fixture_id: number;
+  home_score: number;
+  away_score: number;
+  points: number | null; // null until the result is entered (then 5 / 2 / 0)
+  submitted_at: string;
+  last_amended_at: string | null;
+};
+
+// A single knockout prediction as submitted to POST /api/wc/knockout/picks
+export type KnockoutPickInput = {
+  round_number: number;
+  fixture_id: number;
+  home_score: number;
+  away_score: number;
+};
+
+// Response from PATCH /api/wc/knockout/admin after recording a result
+export type WcKnockoutAdminResultResponse = {
+  success: boolean;
+  fixture_id: number;
+  home_team_score: number;
+  away_team_score: number;
+  // Count of picks on this fixture that were (re-)scored by this request
+  picks_scored: number;
+  was_complete: boolean;
+};
+
+// A league the signed-in user belongs to, for the game selector.
+export type WcLeagueMembership = {
+  league_id: number;
+  name: string;
+  knockout_only: boolean;
+  // Whether the user may submit knockout picks in this league
+  // (survivors only in the original game; everyone in the parallel game).
+  eligible: boolean;
+};
+
+// A row in the knockout points leaderboard for a league.
+export type WcKnockoutStanding = {
+  user_id: number;
+  user_name: string | null;
+  points: number;
+};


### PR DESCRIPTION
## What this adds

The World Cup 2026 **knockout stage** — a Super Six-style score-prediction phase (rounds 7–11: R32, R16, QF, SF, Final). Players predict the exact scoreline of each round's last/predicted match; **5 pts** for the exact score, **2 pts** for the correct result. Plus a **second parallel game** for players who didn't qualify, and a game selector to switch between games.

## Highlights

- **Data:** new `wc_knockout_fixtures` + `wc_knockout_picks` tables (created in Neon); all 31 knockout matches seeded with kickoff times, `is_predicted` per round, Colombia v Ghana pre-filled. `WC_TEAMS` is now a single source of truth for team data.
- **Parallel game:** `leagues` id 4 (`WC_PARALLEL_LEAGUE_ID`), everyone auto-enrolled in both games. Game 1 is survivors-only (eligibility derived from group results via `isSurvivor`); Game 2 is open to all.
- **Deadlines** derive live from each round's predicted fixture (`kickoff − 1h`), editable from the admin page.
- **APIs** (`app/api/wc/knockout/`): fixtures (GET + admin editor PATCH), picks (GET/POST, league-aware, eligibility + deadline gated), leagues, standings, admin (result + scoring), seed.
- **Player UI:** game selector in the hero, Knockout tab = score-prediction form + standings, Group Stage tab hidden for the knockout-only game.
- **Admin UI:** `/admin/knockout` — phone-friendly editor for fixture team names (dropdowns from `WC_TEAMS`), kickoff/predicted flag, and result entry that scores predictions.
- **Tests:** `computeKnockoutPoints` unit-tested.

## Code review fixes included

- Scoring is **round-based** (not by `fixture_id`), so moving a round's predicted match never orphans saved picks from scoring; picks upsert is atomic and rewrites `fixture_id` on amend.
- Rules-tab knockout deadlines are derived from the predicted fixtures (no more stale hardcoded values).
- Picks toast reports the server's `savedCount`.

## Notes / follow-ups (intentionally deferred to their own branches)

- Consolidate `WC_TEAM_FLAGS` into `WC_TEAMS`; dedupe `isValidScore` (×3); extract testable helpers from the picks POST handler; remove localStorage from the group-stage form.
- DB tables/league row/backfill were applied directly in Neon (matches existing repo convention — no migrations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
